### PR TITLE
ci: skip duplicate package releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@fdbc4fdcf7d143a5d0a39e9a02e103b13e309024 # v6.0.4
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "24"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Package release intent
+        run: node scripts/check-package-version.mjs "${{ github.event.pull_request.base.sha }}"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
 
-# Validates and publishes to npm on every push to main.
+# Validates every push to main and publishes versions not yet present on npm.
 # Uses npm Trusted Publishing (OIDC) -- no NPM_TOKEN secret needed.
 # Requires the package to be configured as a Trusted Publisher on npmjs.com
 # linked to this repo and workflow.
-# If the version in package.json is already on the registry, npm publish
-# will fail, signalling that a version bump is needed.
+# Existing versions are successful no-ops; PR CI requires package-affecting
+# changes to include a version bump.
 
 on:
   push:
@@ -93,8 +93,27 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
+      - name: Check npm version
+        id: release
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSIONS=$(npm view "$NAME" versions --json)
+
+          if VERSION="$VERSION" node -e \
+            "const v = JSON.parse(require('node:fs').readFileSync(0, 'utf8')); process.exit((Array.isArray(v) ? v : [v]).includes(process.env.VERSION) ? 0 : 1)" \
+            <<< "$PUBLISHED_VERSIONS"; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping npm publish: $NAME@$VERSION already exists."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Publishing $NAME@$VERSION."
+          fi
+
       - name: Install dependencies
+        if: steps.release.outputs.should_publish == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Publish to npm
+        if: steps.release.outputs.should_publish == 'true'
         run: npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,13 @@ Run `pnpm validate` before opening or updating a PR, not on every commit.
 
 ## Versioning and changelog
 
+Package and skill versions are independent release signals:
+
+- Bump the package version for changes to shipped source, build output, or consumer-facing package metadata.
+- Do not bump the package for skill-only, test-only, workflow-only, or README-only changes. The npm README updates with the next package release; use an intentional patch release only when an npm-facing documentation correction must ship immediately.
+- Bump the skill version when the skill itself changes.
+- The release workflow validates every merge to `main`, but publishes only package versions that are not already on npm. An existing version is a successful no-op.
+
 When asked to bump the version (patch, minor, or major):
 
 1. Bump `version` in `package.json`.

--- a/scripts/check-package-version.mjs
+++ b/scripts/check-package-version.mjs
@@ -1,0 +1,64 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const base = process.argv[2];
+
+if (!base) {
+  throw new Error('Usage: node scripts/check-package-version.mjs <base-ref>');
+}
+
+const currentPackage = JSON.parse(readFileSync('package.json', 'utf8'));
+const basePackage = JSON.parse(
+  execFileSync('git', ['show', `${base}:package.json`], { encoding: 'utf8' }),
+);
+const changedFiles = execFileSync('git', ['diff', '--name-only', base, '--'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n')
+  .filter(Boolean);
+
+const packageSourceChanged = changedFiles.some(
+  (file) =>
+    file.startsWith('src/') ||
+    file === 'tsconfig.json' ||
+    file === 'tsdown.config.ts',
+);
+
+const publishedManifestFields = [
+  'name',
+  'description',
+  'author',
+  'license',
+  'repository',
+  'publishConfig',
+  'type',
+  'sideEffects',
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'peerDependenciesMeta',
+  'bundledDependencies',
+  'files',
+  'exports',
+  'engines',
+];
+
+const publishedManifestChanged = publishedManifestFields.some(
+  (field) =>
+    JSON.stringify(currentPackage[field]) !==
+    JSON.stringify(basePackage[field]),
+);
+
+if (!packageSourceChanged && !publishedManifestChanged) {
+  console.log('No package release required.');
+} else if (currentPackage.version === basePackage.version) {
+  throw new Error(
+    `Package contents changed without a version bump (still ${currentPackage.version}). ` +
+      'Bump package.json and update CHANGELOG.md before merging this package release.',
+  );
+} else {
+  console.log(
+    `Package release requested: ${basePackage.version} -> ${currentPackage.version}.`,
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- treat an already-published package version as a successful release no-op
- require package-affecting PRs to bump `package.json`
- keep skill-only and README-only changes independent from npm releases
- document the package and skill versioning policy

## Verification

- `pnpm validate` (46 files, 542 tests)
- required formatting and generated-artifact commands
- duplicate `phase@0.0.7` detection against npm
- package release-intent checks for both exempt workflow changes and package source changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b08e66ff-4dd8-4546-8d46-8a4f43907dd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b08e66ff-4dd8-4546-8d46-8a4f43907dd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

