### PR TITLE
fix: preserve loop timing across quality changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # phase
 
+## 0.0.9
+
+### Patch Changes
+
+- Preserve `createLoop` frame timing when adaptive quality rebuilds its internal ticker.
+
 ## 0.0.8
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -1235,7 +1235,7 @@ Minimal footprint is a core promise (see [Why phase](#why-phase)). Every export 
 | `createTicker`            |             834 B |
 | `createSight`             |             963 B |
 | `createLifecycle`         |           1.47 kB |
-| `createLoop`              |           2.59 kB |
+| `createLoop`              |           2.62 kB |
 | `createScrollProgress`    |             878 B |
 | `createRenderState`       |             495 B |
 | `createDevicePixelRatio`  |             544 B |
@@ -1249,10 +1249,10 @@ Minimal footprint is a core promise (see [Why phase](#why-phase)). Every export 
 | **Ease**                  |                   |
 | `ease (all)`              |             210 B |
 | **React**                 |                   |
-| `useLoop`                 |           2.82 kB |
+| `useLoop`                 |           2.85 kB |
 | `useLifecycle`            |           1.68 kB |
 | `useSight`                |           1.19 kB |
-| `useCanvas`               |           3.44 kB |
+| `useCanvas`               |           3.48 kB |
 | `useMutation`             |           1.36 kB |
 | `usePointer`              |           1.48 kB |
 | `useScroll`               |           1.72 kB |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A lightweight, lifecycle-aware UI performance layer for the web. Includes tools to optimize render performance, build performant animations, and manage layout and off-screen resources",
   "author": "Vercel",
   "license": "MIT",

--- a/src/core/loop/index.spec.ts
+++ b/src/core/loop/index.spec.ts
@@ -456,6 +456,91 @@ describe('quality signal - frame budget', () => {
     loop.stop();
   });
 
+  it('throttle preserves frame continuity after a frame-budget rebuild', async () => {
+    const { createLoop } = await getModule();
+    const clock = setupManualClock();
+    const el = document.createElement('div');
+    let lastState: unknown;
+    let lastDelta = 0;
+    let lastElapsed = 0;
+    let lastFrame = 0;
+    const loop = createLoop({
+      element: el,
+      onTick: (frame) => {
+        lastState = frame;
+        lastDelta = frame.delta;
+        lastElapsed = frame.elapsed;
+        lastFrame = frame.frame;
+      },
+    });
+    makeSightVisible(el);
+
+    degradeViaBudget(clock);
+    const stateBeforeRebuild = lastState;
+    const elapsedBeforeRebuild = lastElapsed;
+    const frameBeforeRebuild = lastFrame;
+
+    await Promise.resolve();
+    clock.advance(OVER_BUDGET_DELTA);
+
+    expect(lastState).toBe(stateBeforeRebuild);
+    expect(lastDelta).toBeCloseTo(16.67);
+    expect(lastElapsed).toBeGreaterThan(elapsedBeforeRebuild);
+    expect(lastFrame).toBe(frameBeforeRebuild + 1);
+    clock.restore();
+    loop.stop();
+  });
+
+  it('throttle preserves frame continuity across focus changes', async () => {
+    const { createLoop } = await getModule();
+    const clock = setupManualClock();
+    const el = document.createElement('div');
+    let lastState: unknown;
+    let lastDelta = 0;
+    let lastElapsed = 0;
+    let lastFrame = 0;
+    const loop = createLoop({
+      element: el,
+      onTick: (frame) => {
+        lastState = frame;
+        lastDelta = frame.delta;
+        lastElapsed = frame.elapsed;
+        lastFrame = frame.frame;
+      },
+    });
+    makeSightVisible(el);
+    clock.advance(16);
+
+    const initialState = lastState;
+    const initialElapsed = lastElapsed;
+    const initialFrame = lastFrame;
+    const hasFocusSpy = vi.spyOn(document, 'hasFocus');
+    hasFocusSpy.mockReturnValue(false);
+    window.dispatchEvent(new Event('blur'));
+
+    await Promise.resolve();
+    clock.advance(OVER_BUDGET_DELTA);
+
+    expect(lastState).toBe(initialState);
+    expect(lastDelta).toBeCloseTo(16.67);
+    expect(lastElapsed).toBeGreaterThan(initialElapsed);
+    expect(lastFrame).toBe(initialFrame + 1);
+
+    const degradedElapsed = lastElapsed;
+    const degradedFrame = lastFrame;
+    hasFocusSpy.mockReturnValue(true);
+    window.dispatchEvent(new Event('focus'));
+
+    await Promise.resolve();
+    clock.advance(16);
+
+    expect(lastState).toBe(initialState);
+    expect(lastElapsed).toBeGreaterThan(degradedElapsed);
+    expect(lastFrame).toBe(degradedFrame + 1);
+    clock.restore();
+    loop.stop();
+  });
+
   it('pause: degrades then recovers via timer (not permanent)', async () => {
     const { createLoop } = await getModule();
     const clock = setupManualClock();

--- a/src/core/loop/index.ts
+++ b/src/core/loop/index.ts
@@ -139,6 +139,11 @@ export function createLoop(options: LoopOptions): Loop {
   let overBudgetCount = 0;
   let ticker: Ticker | null = null;
 
+  // The adaptive-quality ticker can be replaced while the loop is running.
+  // Keep the consumer-facing frame owned by the loop so its timeline and
+  // object identity remain continuous across those internal replacements.
+  const frame: FrameState = { time: 0, delta: 0, elapsed: 0, frame: 0 };
+
   // Quality signal flags
   let focusDegraded = false;
 
@@ -220,12 +225,17 @@ export function createLoop(options: LoopOptions): Loop {
   function buildTicker(): void {
     const targetFps: number | undefined = getEffectiveFps();
     const budget: number = 1000 / (targetFps ?? 60);
+    const elapsedOffset: number = frame.elapsed;
 
     destroyTicker();
 
     ticker = createTicker({
       fps: targetFps,
-      onTick: (frame) => {
+      onTick: (tickerFrame) => {
+        frame.time = tickerFrame.time;
+        frame.delta = tickerFrame.delta;
+        frame.elapsed = elapsedOffset + tickerFrame.elapsed;
+        frame.frame++;
         checkFrameBudget(frame.delta, budget);
         onTick(frame);
       },


### PR DESCRIPTION
Keeps `createLoop`'s public `FrameState` continuous when adaptive quality rebuilds its internal ticker. Previously a frame-budget or focus-driven FPS change reset `elapsed`, `frame`, and object identity, which could restart elapsed-time animation sequences.

## Details

- `createLoop` now owns one preallocated frame and offsets each replacement ticker's elapsed time into the same timeline.
- Adds deterministic regressions for frame-budget degradation and blur/focus quality changes.
- Bumps `phase` to `0.0.9` and refreshes the generated bundle-size table.
- `pnpm validate`: 50 test files, 587 tests, typecheck, lint, format, and skill coverage passed.
- `pnpm build` and `pnpm size` passed. `createLoop` moves from 2.59 to 2.62 kB Brotli against a 2.85 kB limit.
