### PR TITLE
Use prepare instead of postinstall for lefthook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "size": "size-limit",
     "size:readme": "node scripts/update-size-table.mjs",
     "prepublishOnly": "pnpm build",
-    "postinstall": "lefthook install || true",
+    "prepare": "lefthook install || true",
     "validate": "pnpm run --parallel '/^(typecheck|lint|format|test|skill:check)$/'",
     "skill:check": "node scripts/skill/check-coverage.mjs && node scripts/skill/check-scan-sync.mjs",
     "skill:build": "node scripts/skill/build-metadata.mjs && node scripts/skill/sync-scan-docs.mjs",


### PR DESCRIPTION
`postinstall` runs on every consumer's install of the published `phase` package. lefthook is a devDependency, so the script is a harmless no-op there thanks to `|| true` — but it still marks the package as running install scripts (flagged by Socket and similar scanners, blocked by default in pnpm 10+).

`prepare` runs only in the package's own dev checkout after `pnpm install` (and before pack/publish), which is the only place installing git hooks is wanted. Contributor experience is unchanged: clone → `pnpm install` → hooks installed.

Found while extracting a package that copied phase's tooling setup; applying the same fix upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)