### PR TITLE
ci: run CI and Size on every open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  # Every open PR, not just those targeting main, so stacked PRs get a signal
+  # before the branch below them merges. Base-relative steps stay correct: the
+  # release-intent check diffs against the PR's own base.
   pull_request:
-    branches: [main]
 
 # Cancel in-progress PR runs on new pushes; let main runs finish so the
 # release workflow's history stays uninterrupted.

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,8 +1,9 @@
 name: Size
 
 on:
+  # Every open PR, so a stacked PR is measured against the branch below it and
+  # its reported delta is its own contribution rather than the whole stack's.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: size-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

Both workflows filter on `pull_request: branches: [main]`, so a PR stacked on another branch gets no checks at all. #37 currently has zero CI and stays that way until #35 merges and it retargets, which defers the signal to the worst possible moment: after the parent is already in.

## Solution

Drop the `branches` filter from both workflows so every open PR runs.

I checked the two base-relative steps before doing this, and they read *better* on a stack than they would against main:

- `check-package-version.mjs` diffs against `github.event.pull_request.base.sha`, so each PR in a stack must carry its own version bump instead of inheriting the parent's.
- `size-limit-action` compares head against base, so a stacked PR's reported delta is its own contribution rather than the whole stack's.

## Notes

Green on a stacked PR only means it passes against the branch below it. The run against `main` happens when it retargets, so stack green is a weaker guarantee than main green.

Considered allowlisting `runewolf/**` instead. Dropping the filter is better than hardcoding one person's branch convention into shared CI.

Unrelated, spotted while reading: `ci.yml`'s concurrency comment says "let main runs finish so the release workflow's history stays uninterrupted" and gates on `github.event_name == 'pull_request'`, but the workflow only has a `pull_request` trigger, so that expression is always true and there are no main runs to protect. Left alone.