### PR TITLE
fix: let pooled observers carry more than one subscriber per element

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -51,7 +51,7 @@
     "name": "createPointer",
     "path": "src/index.ts",
     "import": "{ createPointer }",
-    "limit": "1.3 kB"
+    "limit": "1.42 kB"
   },
   {
     "name": "createScroll",
@@ -107,7 +107,7 @@
     "path": "src/react/index.ts",
     "import": "{ useSight }",
     "ignore": ["react"],
-    "limit": "1.4 kB"
+    "limit": "1.5 kB"
   },
   {
     "name": "useCanvas",
@@ -177,14 +177,14 @@
     "path": "src/react/index.ts",
     "import": "{ useSize }",
     "ignore": ["react"],
-    "limit": "410 B"
+    "limit": "500 B"
   },
   {
     "name": "useContainerQuery",
     "path": "src/react/index.ts",
     "import": "{ useContainerQuery }",
     "ignore": ["react"],
-    "limit": "400 B"
+    "limit": "470 B"
   },
   {
     "name": "useMediaQuery",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # phase
 
+## 0.3.1
+
+### Patch Changes
+
+- Pooled IntersectionObserver and ResizeObserver support multiple subscribers per element. A second subscriber on the same element previously replaced the first, so one of two hooks watching the same node stopped receiving updates, and the element was unobserved as soon as either cleaned up. Both pools now track a set of subscribers and release the element only once the last one is gone, matching the MediaQueryList pool.
+- Raised the `useSize` size budget to cover the pooling fix and restore the documented headroom.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - Pooled IntersectionObserver and ResizeObserver support multiple subscribers per element. A second subscriber on the same element previously replaced the first, so one of two hooks watching the same node stopped receiving updates, and the element was unobserved as soon as either cleaned up. Both pools now track a set of subscribers and release the element only once the last one is gone, matching the MediaQueryList pool.
-- Raised the `useSize` size budget to cover the pooling fix and restore the documented headroom.
+- Raised the `useSize`, `useSight`, `createPointer`, and `useContainerQuery` size budgets to cover the pooling fix and restore the documented headroom.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -1236,15 +1236,15 @@ Minimal footprint is a core promise (see [Why phase](#why-phase)). Every export 
 | ------------------------- | ----------------: |
 | **Core**                  |                   |
 | `createTicker`            |             847 B |
-| `createSight`             |           1.01 kB |
-| `createLifecycle`         |           1.52 kB |
-| `createLoop`              |           2.65 kB |
-| `createScrollProgress`    |             869 B |
+| `createSight`             |           1.05 kB |
+| `createLifecycle`         |           1.55 kB |
+| `createLoop`              |           2.68 kB |
+| `createScrollProgress`    |             895 B |
 | `createRenderState`       |             490 B |
 | `createDevicePixelRatio`  |             544 B |
-| `createMutation`          |           1.17 kB |
-| `createPointer`           |           1.26 kB |
-| `createScroll`            |           1.56 kB |
+| `createMutation`          |           1.21 kB |
+| `createPointer`           |           1.29 kB |
+| `createScroll`            |           1.61 kB |
 | `createThrottle`          |             660 B |
 | `createDebounce`          |             558 B |
 | `whenIdle`                |             409 B |
@@ -1252,27 +1252,27 @@ Minimal footprint is a core promise (see [Why phase](#why-phase)). Every export 
 | **Ease**                  |                   |
 | `ease (all)`              |             210 B |
 | **React**                 |                   |
-| `useLoop`                 |           2.98 kB |
-| `useLifecycle`            |           1.81 kB |
-| `useSight`                |           1.33 kB |
-| `useCanvas`               |           3.51 kB |
-| `useMutation`             |           1.36 kB |
-| `usePointer`              |           1.47 kB |
-| `useScroll`               |            1.9 kB |
+| `useLoop`                 |              3 kB |
+| `useLifecycle`            |           1.83 kB |
+| `useSight`                |           1.36 kB |
+| `useCanvas`               |           3.58 kB |
+| `useMutation`             |           1.39 kB |
+| `usePointer`              |           1.51 kB |
+| `useScroll`               |           1.96 kB |
 | `useThrottledCallback`    |             804 B |
 | `useDebouncedCallback`    |             696 B |
 | `useTween`                |             680 B |
 | `usePresence`             |             591 B |
-| `useScrollProgress`       |             991 B |
-| `useSize`                 |             378 B |
-| `useContainerQuery`       |             384 B |
+| `useScrollProgress`       |           1.03 kB |
+| `useSize`                 |             418 B |
+| `useContainerQuery`       |             389 B |
 | `useMediaQuery`           |             246 B |
 | `usePrefersReducedMotion` |             272 B |
 | `useDevicePixelRatio`     |             231 B |
 | `useSyncedRef`            |              22 B |
 | `useStableCallback`       |              39 B |
 | `Presence`                |             741 B |
-| `WhenVisible`             |           1.57 kB |
+| `WhenVisible`             |           1.61 kB |
 | `WhenIdle`                |             596 B |
 | `Defer`                   |              86 B |
 | `useIdle`                 |             414 B |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phase",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A lightweight, lifecycle-aware UI performance layer for the web. Includes tools to optimize render performance, build performant animations, and manage layout and off-screen resources",
   "author": "Vercel",
   "license": "MIT",

--- a/src/__mocks__/match-media.ts
+++ b/src/__mocks__/match-media.ts
@@ -1,6 +1,8 @@
 export interface MockMatchMediaResult {
   mockMatchMedia: typeof matchMedia;
   setMatches: (query: string, matches: boolean) => void;
+  /** Change listeners currently attached for a query, for leak assertions. */
+  listenerCount: (query: string) => number;
 }
 
 export function createMockMatchMedia(): MockMatchMediaResult {
@@ -64,5 +66,13 @@ export function createMockMatchMedia(): MockMatchMediaResult {
     }
   }
 
-  return { mockMatchMedia: mockMatchMedia as typeof matchMedia, setMatches };
+  function listenerCount(query: string): number {
+    return queries.get(query)?.listeners.size ?? 0;
+  }
+
+  return {
+    mockMatchMedia: mockMatchMedia as typeof matchMedia,
+    setMatches,
+    listenerCount,
+  };
 }

--- a/src/core/_internal/pool/dpr.spec.ts
+++ b/src/core/_internal/pool/dpr.spec.ts
@@ -1,0 +1,41 @@
+import { createMockMatchMedia } from '../../../__mocks__/match-media';
+import { describePoolContract } from './pool-contract';
+
+let mockMM: ReturnType<typeof createMockMatchMedia>;
+/** Tracks the DPR the pool is currently bound to; it rebinds on every change. */
+let currentDpr: number;
+
+beforeEach(() => {
+  mockMM = createMockMatchMedia();
+  currentDpr = 2;
+  vi.stubGlobal('matchMedia', mockMM.mockMatchMedia);
+  vi.stubGlobal('devicePixelRatio', currentDpr);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+const resolutionQuery = (dpr: number): string => `(resolution: ${dpr}dppx)`;
+
+// A single process-wide subscription rather than a keyed one, so the contract
+// runs with one key and the adapter ignores it.
+describePoolContract<'dpr'>({
+  keys: () => ['dpr'],
+  create: async () => {
+    const { subscribeDpr } = await import('./dpr');
+    return {
+      subscribe: (_key, callback) => subscribeDpr(() => callback()),
+      notify: () => {
+        const previous = currentDpr;
+        currentDpr += 1;
+        vi.stubGlobal('devicePixelRatio', currentDpr);
+        // The pool listens on the query for the DPR it last saw, so the change
+        // is announced against the previous resolution.
+        mockMM.setMatches(resolutionQuery(previous), false);
+      },
+      isBound: () => mockMM.listenerCount(resolutionQuery(currentDpr)) > 0,
+    };
+  },
+});

--- a/src/core/_internal/pool/io-pool.spec.ts
+++ b/src/core/_internal/pool/io-pool.spec.ts
@@ -167,11 +167,11 @@ describe('cleanup', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Ownership safety
+// Multiple subscribers per element
 // ---------------------------------------------------------------------------
 
-describe('ownership safety', () => {
-  it('second subscription on same element overwrites callback', async () => {
+describe('multiple subscribers per element', () => {
+  it('every subscriber on an element receives the entry', async () => {
     const { observeIntersection } = await getModule();
     const el = document.createElement('div');
     const cb1 = vi.fn();
@@ -182,34 +182,53 @@ describe('ownership safety', () => {
 
     mockIO.trigger(el, true);
 
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+
+  it('one subscriber cleaning up leaves the others observed', async () => {
+    const { observeIntersection } = await getModule();
+    const el = document.createElement('div');
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const cleanup1 = observeIntersection({ element: el, onIntersect: cb1 });
+    observeIntersection({ element: el, onIntersect: cb2 });
+
+    cleanup1();
+    expect(firstInstance().observed.has(el)).toBe(true);
+
+    mockIO.trigger(el, true);
     expect(cb1).not.toHaveBeenCalled();
     expect(cb2).toHaveBeenCalledTimes(1);
   });
 
-  it('first cleanup does NOT unobserve if second subscription replaced it', async () => {
+  it('unobserves only after the last subscriber cleans up', async () => {
     const { observeIntersection } = await getModule();
     const el = document.createElement('div');
     const cleanup1 = observeIntersection({ element: el, onIntersect: vi.fn() });
-    const cb2 = vi.fn();
-    observeIntersection({ element: el, onIntersect: cb2 });
-
-    cleanup1();
-
-    // el should still be observed (owned by second subscription)
-    expect(firstInstance().observed.has(el)).toBe(true);
-
-    mockIO.trigger(el, true);
-    expect(cb2).toHaveBeenCalledTimes(1);
-  });
-
-  it('second cleanup correctly unobserves', async () => {
-    const { observeIntersection } = await getModule();
-    const el = document.createElement('div');
-    observeIntersection({ element: el, onIntersect: vi.fn() });
     const cleanup2 = observeIntersection({ element: el, onIntersect: vi.fn() });
 
+    cleanup1();
+    expect(firstInstance().observed.has(el)).toBe(true);
     cleanup2();
     expect(firstInstance().observed.has(el)).toBe(false);
+  });
+
+  it('drops the pooled observer once its last element is released', async () => {
+    const { observeIntersection } = await getModule();
+    const el = document.createElement('div');
+    const cleanup1 = observeIntersection({ element: el, onIntersect: vi.fn() });
+    const cleanup2 = observeIntersection({ element: el, onIntersect: vi.fn() });
+    expect(mockIO.instances).toHaveLength(1);
+
+    // The pool entry survives while any subscriber remains, so the same IO is
+    // reused rather than rebuilt.
+    cleanup1();
+    observeIntersection({ element: el, onIntersect: vi.fn() });
+    expect(mockIO.instances).toHaveLength(1);
+    expect(firstInstance().observed.has(el)).toBe(true);
+
+    cleanup2();
   });
 });
 

--- a/src/core/_internal/pool/io-pool.spec.ts
+++ b/src/core/_internal/pool/io-pool.spec.ts
@@ -1,4 +1,5 @@
 import { createMockIntersectionObserver } from '../../../__mocks__/intersection-observer';
+import { describePoolContract } from './pool-contract';
 
 let mockIO: ReturnType<typeof createMockIntersectionObserver>;
 
@@ -166,70 +167,43 @@ describe('cleanup', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Multiple subscribers per element
-// ---------------------------------------------------------------------------
-
-describe('multiple subscribers per element', () => {
-  it('every subscriber on an element receives the entry', async () => {
+describe('late subscribers', () => {
+  it('does not receive the initial entry for an already-observed element', async () => {
     const { observeIntersection } = await getModule();
     const el = document.createElement('div');
-    const cb1 = vi.fn();
-    const cb2 = vi.fn();
+    const early = vi.fn();
+    const late = vi.fn();
 
-    observeIntersection({ element: el, onIntersect: cb1 });
-    observeIntersection({ element: el, onIntersect: cb2 });
-
+    observeIntersection({ element: el, onIntersect: early });
     mockIO.trigger(el, true);
 
-    expect(cb1).toHaveBeenCalledTimes(1);
-    expect(cb2).toHaveBeenCalledTimes(1);
-  });
-
-  it('one subscriber cleaning up leaves the others observed', async () => {
-    const { observeIntersection } = await getModule();
-    const el = document.createElement('div');
-    const cb1 = vi.fn();
-    const cb2 = vi.fn();
-    const cleanup1 = observeIntersection({ element: el, onIntersect: cb1 });
-    observeIntersection({ element: el, onIntersect: cb2 });
-
-    cleanup1();
-    expect(firstInstance().observed.has(el)).toBe(true);
+    // `observe()` is a no-op for a target the observer already holds, so this
+    // subscriber waits for the next change rather than learning current state.
+    observeIntersection({ element: el, onIntersect: late });
+    expect(late).not.toHaveBeenCalled();
 
     mockIO.trigger(el, true);
-    expect(cb1).not.toHaveBeenCalled();
-    expect(cb2).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(early).toHaveBeenCalledTimes(2);
   });
+});
 
-  it('unobserves only after the last subscriber cleans up', async () => {
+// ---------------------------------------------------------------------------
+// Shared pool contract
+// ---------------------------------------------------------------------------
+
+describePoolContract<Element>({
+  keys: () => [document.createElement('div'), document.createElement('div')],
+  create: async () => {
     const { observeIntersection } = await getModule();
-    const el = document.createElement('div');
-    const cleanup1 = observeIntersection({ element: el, onIntersect: vi.fn() });
-    const cleanup2 = observeIntersection({ element: el, onIntersect: vi.fn() });
-
-    cleanup1();
-    expect(firstInstance().observed.has(el)).toBe(true);
-    cleanup2();
-    expect(firstInstance().observed.has(el)).toBe(false);
-  });
-
-  it('drops the pooled observer once its last element is released', async () => {
-    const { observeIntersection } = await getModule();
-    const el = document.createElement('div');
-    const cleanup1 = observeIntersection({ element: el, onIntersect: vi.fn() });
-    const cleanup2 = observeIntersection({ element: el, onIntersect: vi.fn() });
-    expect(mockIO.instances).toHaveLength(1);
-
-    // The pool entry survives while any subscriber remains, so the same IO is
-    // reused rather than rebuilt.
-    cleanup1();
-    observeIntersection({ element: el, onIntersect: vi.fn() });
-    expect(mockIO.instances).toHaveLength(1);
-    expect(firstInstance().observed.has(el)).toBe(true);
-
-    cleanup2();
-  });
+    return {
+      subscribe: (element, callback) =>
+        observeIntersection({ element, onIntersect: callback }),
+      notify: (element) => mockIO.trigger(element, true),
+      isBound: (element) =>
+        mockIO.instances.some((instance) => instance.observed.has(element)),
+    };
+  },
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/_internal/pool/io-pool.ts
+++ b/src/core/_internal/pool/io-pool.ts
@@ -18,8 +18,13 @@ const pool = new Map<string, IOPoolEntry>();
 /**
  * Observe an element via a shared IntersectionObserver pool.
  * Elements with identical options share one IO instance. An element may have
- * any number of subscribers; each receives every entry, and the element stays
- * observed until the last one cleans up.
+ * any number of subscribers; each receives every entry delivered after it
+ * subscribes, and the element stays observed until the last one cleans up.
+ *
+ * A subscriber joining an already-observed element does not get the initial
+ * entry: `observe()` is a no-op for a target the observer already holds, so
+ * nothing arrives until the next intersection change. Callers that need
+ * current state on subscribe have to read it themselves.
  *
  * @returns Cleanup function that removes this subscriber, unobserving the
  * element once none remain and dropping the IO once it observes nothing.

--- a/src/core/_internal/pool/io-pool.ts
+++ b/src/core/_internal/pool/io-pool.ts
@@ -10,16 +10,19 @@ export interface ObserveIntersectionOptions {
 
 interface IOPoolEntry {
   observer: IntersectionObserver;
-  callbacks: Map<Element, IOCallback>;
+  callbacks: Map<Element, Set<IOCallback>>;
 }
 
 const pool = new Map<string, IOPoolEntry>();
 
 /**
  * Observe an element via a shared IntersectionObserver pool.
- * Elements with identical options share one IO instance.
+ * Elements with identical options share one IO instance. An element may have
+ * any number of subscribers; each receives every entry, and the element stays
+ * observed until the last one cleans up.
  *
- * @returns Cleanup function that unobserves the element and removes the IO if empty.
+ * @returns Cleanup function that removes this subscriber, unobserving the
+ * element once none remain and dropping the IO once it observes nothing.
  */
 export function observeIntersection(
   options: ObserveIntersectionOptions,
@@ -30,7 +33,12 @@ export function observeIntersection(
   const key: string = getPoolKey(ioInit);
   const entry: IOPoolEntry = getOrCreatePoolEntry(key, ioInit);
 
-  entry.callbacks.set(element, onIntersect);
+  let subscribers: Set<IOCallback> | undefined = entry.callbacks.get(element);
+  if (!subscribers) {
+    subscribers = new Set();
+    entry.callbacks.set(element, subscribers);
+  }
+  subscribers.add(onIntersect);
   entry.observer.observe(element);
 
   let disposed = false;
@@ -42,11 +50,16 @@ export function observeIntersection(
     const poolEntry: IOPoolEntry | undefined = pool.get(key);
     if (!poolEntry) return;
 
-    // Only unobserve if our callback is still the registered one.
-    // A later subscription on the same element would have overwritten it.
-    if (poolEntry.callbacks.get(element) === onIntersect) {
-      poolEntry.observer.unobserve(element);
-      poolEntry.callbacks.delete(element);
+    // Unobserve once this element has no subscribers left; other subscribers
+    // on the same element must keep receiving entries.
+    const current: Set<IOCallback> | undefined =
+      poolEntry.callbacks.get(element);
+    if (current) {
+      current.delete(onIntersect);
+      if (current.size === 0) {
+        poolEntry.observer.unobserve(element);
+        poolEntry.callbacks.delete(element);
+      }
     }
 
     if (poolEntry.callbacks.size === 0) {
@@ -90,11 +103,16 @@ function getOrCreatePoolEntry(
 
 /** Create a new pool entry for the given options. */
 const createPoolEntry = (options: IntersectionObserverInit): IOPoolEntry => {
-  const callbacks = new Map<Element, IOCallback>();
+  const callbacks = new Map<Element, Set<IOCallback>>();
   const observer = new IntersectionObserver((entries) => {
     for (const ioEntry of entries) {
-      const cb: IOCallback | undefined = callbacks.get(ioEntry.target);
-      if (cb) cb(ioEntry);
+      const subscribers: Set<IOCallback> | undefined = callbacks.get(
+        ioEntry.target,
+      );
+      if (!subscribers) continue;
+      // Iterated directly rather than copied: Set iteration already tolerates
+      // a subscriber removing itself, which is the reentrant case that happens.
+      for (const cb of subscribers) cb(ioEntry);
     }
   }, options);
 

--- a/src/core/_internal/pool/mql-pool.spec.ts
+++ b/src/core/_internal/pool/mql-pool.spec.ts
@@ -1,4 +1,5 @@
 import { createMockMatchMedia } from '../../../__mocks__/match-media';
+import { describePoolContract } from './pool-contract';
 
 let mockMM: ReturnType<typeof createMockMatchMedia>;
 
@@ -136,4 +137,21 @@ describe('readMediaQuery', () => {
     mockMM.setMatches('(max-width: 600px)', true);
     expect(cb).not.toHaveBeenCalled();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Shared pool contract
+// ---------------------------------------------------------------------------
+
+describePoolContract<string>({
+  keys: () => ['(min-width: 600px)', '(min-width: 900px)'],
+  create: async () => {
+    const { subscribeMediaQuery } = await getModule();
+    return {
+      subscribe: (query, callback) =>
+        subscribeMediaQuery(query, () => callback()),
+      notify: (query) => mockMM.setMatches(query, true),
+      isBound: (query) => mockMM.listenerCount(query) > 0,
+    };
+  },
 });

--- a/src/core/_internal/pool/pool-contract.ts
+++ b/src/core/_internal/pool/pool-contract.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared behavioral contract for phase's subscription pools.
+ *
+ * Every pool wraps a browser resource that is expensive or leaky to hold, and
+ * every one of them makes the same four promises: fan out to all subscribers of
+ * a key, keep the survivors alive when one leaves, release the resource only
+ * once the last leaves, and stay safe when a subscriber removes itself from its
+ * own callback.
+ *
+ * Those promises were previously left implicit, and the IO and RO pools both
+ * broke the first two independently. Each pool runs this suite against a small
+ * adapter so the contract is stated once and enforced everywhere, without
+ * shipping a shared runtime abstraction (the pools differ in keying depth and
+ * in how they acquire and release, and their bytes are budgeted per export).
+ *
+ * This file is a test helper. It is only imported from `.spec` files, so it
+ * never reaches a bundle.
+ */
+
+/** A pool's surface, reduced to what the contract needs. */
+export interface PoolAdapter<K> {
+  /** Subscribe to `key`; returns the pool's own cleanup function. */
+  subscribe(key: K, callback: () => void): () => void;
+  /** Deliver one notification to every subscriber of `key`. */
+  notify(key: K): void;
+  /** Whether the pool still holds the browser resource behind `key`. */
+  isBound(key: K): boolean;
+}
+
+export interface PoolContract<K> {
+  /**
+   * Distinct keys, built fresh per test. A single entry means the pool has one
+   * implicit key (a process-wide subscription rather than a keyed one).
+   */
+  keys(): readonly [K, ...K[]];
+  /** Build the pool surface. Called inside each test, after mocks install. */
+  create(): Promise<PoolAdapter<K>>;
+}
+
+/**
+ * Register the shared pool contract. Call from a pool's spec after its
+ * `beforeEach` installs the relevant browser mocks.
+ */
+export function describePoolContract<K>(contract: PoolContract<K>): void {
+  // Read once at collection time purely to decide whether the multi-key clause
+  // applies; each test builds its own fresh keys.
+  const isKeyed: boolean = contract.keys().length > 1;
+
+  describe('pool subscription contract', () => {
+    it('delivers every notification to every subscriber of a key', async () => {
+      const pool = await contract.create();
+      const [key] = contract.keys();
+      const first = vi.fn();
+      const second = vi.fn();
+
+      pool.subscribe(key, first);
+      pool.subscribe(key, second);
+      pool.notify(key);
+
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the remaining subscribers when one releases', async () => {
+      const pool = await contract.create();
+      const [key] = contract.keys();
+      const leaving = vi.fn();
+      const staying = vi.fn();
+
+      const release = pool.subscribe(key, leaving);
+      pool.subscribe(key, staying);
+
+      release();
+      pool.notify(key);
+
+      expect(leaving).not.toHaveBeenCalled();
+      expect(staying).toHaveBeenCalledTimes(1);
+    });
+
+    it('holds the resource until the last subscriber releases', async () => {
+      const pool = await contract.create();
+      const [key] = contract.keys();
+
+      const releaseFirst = pool.subscribe(key, vi.fn());
+      const releaseSecond = pool.subscribe(key, vi.fn());
+      expect(pool.isBound(key)).toBe(true);
+
+      releaseFirst();
+      expect(pool.isBound(key)).toBe(true);
+
+      releaseSecond();
+      expect(pool.isBound(key)).toBe(false);
+    });
+
+    it('treats a repeated release as a no-op and keeps a later subscriber', async () => {
+      const pool = await contract.create();
+      const [key] = contract.keys();
+
+      const release = pool.subscribe(key, vi.fn());
+      release();
+
+      const later = vi.fn();
+      pool.subscribe(key, later);
+      release(); // already spent; must not disturb the new subscriber
+
+      expect(pool.isBound(key)).toBe(true);
+      pool.notify(key);
+      expect(later).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets a subscriber release itself from inside its own callback', async () => {
+      const pool = await contract.create();
+      const [key] = contract.keys();
+      const other = vi.fn();
+      let releaseSelf: (() => void) | undefined;
+      const selfReleasing = vi.fn(() => releaseSelf?.());
+
+      releaseSelf = pool.subscribe(key, selfReleasing);
+      pool.subscribe(key, other);
+
+      expect(() => pool.notify(key)).not.toThrow();
+      expect(selfReleasing).toHaveBeenCalledTimes(1);
+      expect(other).toHaveBeenCalledTimes(1);
+
+      pool.notify(key);
+      expect(selfReleasing).toHaveBeenCalledTimes(1);
+      expect(other).toHaveBeenCalledTimes(2);
+    });
+
+    // Single-key pools have nothing to isolate.
+    it.skipIf(!isKeyed)('keeps separate keys independent', async () => {
+      const pool = await contract.create();
+      const [keyA, keyB] = contract.keys();
+      if (keyB === undefined) return;
+      const onA = vi.fn();
+      const onB = vi.fn();
+
+      pool.subscribe(keyA, onA);
+      const releaseB = pool.subscribe(keyB, onB);
+
+      pool.notify(keyA);
+      expect(onA).toHaveBeenCalledTimes(1);
+      expect(onB).not.toHaveBeenCalled();
+
+      releaseB();
+      expect(pool.isBound(keyA)).toBe(true);
+    });
+  });
+}

--- a/src/core/_internal/pool/ro-pool.spec.ts
+++ b/src/core/_internal/pool/ro-pool.spec.ts
@@ -1,4 +1,5 @@
 import { createMockResizeObserver } from '../../../__mocks__/resize-observer';
+import { describePoolContract } from './pool-contract';
 
 let mockRO: ReturnType<typeof createMockResizeObserver>;
 
@@ -117,83 +118,18 @@ describe('cleanup', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Multiple subscribers per element
+// Shared pool contract
 // ---------------------------------------------------------------------------
 
-describe('multiple subscribers per element', () => {
-  it('every subscriber on an element receives the entry', async () => {
+describePoolContract<Element>({
+  keys: () => [document.createElement('div'), document.createElement('div')],
+  create: async () => {
     const { observeResize } = await getModule();
-    const el = document.createElement('div');
-    const cb1 = vi.fn();
-    const cb2 = vi.fn();
-    observeResize(el, cb1);
-    observeResize(el, cb2);
-
-    mockRO.trigger(el, 100, 50);
-    expect(cb1).toHaveBeenCalledTimes(1);
-    expect(cb2).toHaveBeenCalledTimes(1);
-  });
-
-  it('one subscriber cleaning up leaves the others observed', async () => {
-    const { observeResize } = await getModule();
-    const el = document.createElement('div');
-    const cb1 = vi.fn();
-    const cb2 = vi.fn();
-    const cleanup1 = observeResize(el, cb1);
-    observeResize(el, cb2);
-
-    cleanup1();
-    expect(firstInstance().observed.has(el)).toBe(true);
-
-    mockRO.trigger(el, 100, 50);
-    expect(cb1).not.toHaveBeenCalled();
-    expect(cb2).toHaveBeenCalledTimes(1);
-  });
-
-  it('unobserves only after the last subscriber cleans up', async () => {
-    const { observeResize } = await getModule();
-    const el = document.createElement('div');
-    const cleanup1 = observeResize(el, vi.fn());
-    const cleanup2 = observeResize(el, vi.fn());
-
-    cleanup1();
-    expect(firstInstance().observed.has(el)).toBe(true);
-    cleanup2();
-    expect(firstInstance().observed.has(el)).toBe(false);
-  });
-
-  it('a repeated cleanup does not evict a later subscriber', async () => {
-    const { observeResize } = await getModule();
-    const el = document.createElement('div');
-    const cleanup1 = observeResize(el, vi.fn());
-    cleanup1();
-
-    const cb2 = vi.fn();
-    observeResize(el, cb2);
-    cleanup1(); // idempotent, and must not touch cb2's subscription
-
-    expect(firstInstance().observed.has(el)).toBe(true);
-    mockRO.trigger(el, 100, 50);
-    expect(cb2).toHaveBeenCalledTimes(1);
-  });
-
-  it('a subscriber may unsubscribe from inside its own callback', async () => {
-    const { observeResize } = await getModule();
-    const el = document.createElement('div');
-    const other = vi.fn();
-    let cleanupSelf: (() => void) | undefined;
-    const selfRemoving = vi.fn(() => cleanupSelf?.());
-
-    cleanupSelf = observeResize(el, selfRemoving);
-    observeResize(el, other);
-
-    expect(() => mockRO.trigger(el, 100, 50)).not.toThrow();
-    expect(selfRemoving).toHaveBeenCalledTimes(1);
-    expect(other).toHaveBeenCalledTimes(1);
-
-    // The self-removing subscriber is gone; the other one keeps working.
-    mockRO.trigger(el, 200, 80);
-    expect(selfRemoving).toHaveBeenCalledTimes(1);
-    expect(other).toHaveBeenCalledTimes(2);
-  });
+    return {
+      subscribe: (element, callback) => observeResize(element, callback),
+      notify: (element) => mockRO.trigger(element, 100, 50),
+      isBound: (element) =>
+        mockRO.instances.some((instance) => instance.observed.has(element)),
+    };
+  },
 });

--- a/src/core/_internal/pool/ro-pool.spec.ts
+++ b/src/core/_internal/pool/ro-pool.spec.ts
@@ -117,11 +117,11 @@ describe('cleanup', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Ownership safety
+// Multiple subscribers per element
 // ---------------------------------------------------------------------------
 
-describe('ownership safety', () => {
-  it('second subscription on same element overwrites callback', async () => {
+describe('multiple subscribers per element', () => {
+  it('every subscriber on an element receives the entry', async () => {
     const { observeResize } = await getModule();
     const el = document.createElement('div');
     const cb1 = vi.fn();
@@ -130,30 +130,70 @@ describe('ownership safety', () => {
     observeResize(el, cb2);
 
     mockRO.trigger(el, 100, 50);
-    expect(cb1).not.toHaveBeenCalled();
+    expect(cb1).toHaveBeenCalledTimes(1);
     expect(cb2).toHaveBeenCalledTimes(1);
   });
 
-  it('first cleanup does NOT unobserve if second subscription replaced it', async () => {
+  it('one subscriber cleaning up leaves the others observed', async () => {
     const { observeResize } = await getModule();
     const el = document.createElement('div');
-    const cleanup1 = observeResize(el, vi.fn());
+    const cb1 = vi.fn();
     const cb2 = vi.fn();
+    const cleanup1 = observeResize(el, cb1);
     observeResize(el, cb2);
 
     cleanup1();
     expect(firstInstance().observed.has(el)).toBe(true);
 
     mockRO.trigger(el, 100, 50);
+    expect(cb1).not.toHaveBeenCalled();
     expect(cb2).toHaveBeenCalledTimes(1);
   });
 
-  it('second cleanup correctly unobserves', async () => {
+  it('unobserves only after the last subscriber cleans up', async () => {
     const { observeResize } = await getModule();
     const el = document.createElement('div');
-    observeResize(el, vi.fn());
+    const cleanup1 = observeResize(el, vi.fn());
     const cleanup2 = observeResize(el, vi.fn());
+
+    cleanup1();
+    expect(firstInstance().observed.has(el)).toBe(true);
     cleanup2();
     expect(firstInstance().observed.has(el)).toBe(false);
+  });
+
+  it('a repeated cleanup does not evict a later subscriber', async () => {
+    const { observeResize } = await getModule();
+    const el = document.createElement('div');
+    const cleanup1 = observeResize(el, vi.fn());
+    cleanup1();
+
+    const cb2 = vi.fn();
+    observeResize(el, cb2);
+    cleanup1(); // idempotent, and must not touch cb2's subscription
+
+    expect(firstInstance().observed.has(el)).toBe(true);
+    mockRO.trigger(el, 100, 50);
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+
+  it('a subscriber may unsubscribe from inside its own callback', async () => {
+    const { observeResize } = await getModule();
+    const el = document.createElement('div');
+    const other = vi.fn();
+    let cleanupSelf: (() => void) | undefined;
+    const selfRemoving = vi.fn(() => cleanupSelf?.());
+
+    cleanupSelf = observeResize(el, selfRemoving);
+    observeResize(el, other);
+
+    expect(() => mockRO.trigger(el, 100, 50)).not.toThrow();
+    expect(selfRemoving).toHaveBeenCalledTimes(1);
+    expect(other).toHaveBeenCalledTimes(1);
+
+    // The self-removing subscriber is gone; the other one keeps working.
+    mockRO.trigger(el, 200, 80);
+    expect(selfRemoving).toHaveBeenCalledTimes(1);
+    expect(other).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/core/_internal/pool/ro-pool.ts
+++ b/src/core/_internal/pool/ro-pool.ts
@@ -1,21 +1,34 @@
 type ROCallback = (entry: ResizeObserverEntry) => void;
 
 let observer: ResizeObserver | null = null;
-const callbacks = new Map<Element, ROCallback>();
+const callbacks = new Map<Element, Set<ROCallback>>();
 
 /**
  * Observe an element via a singleton ResizeObserver.
- * One RO instance for the entire page. Per-element `box` options are
- * forwarded to `ResizeObserver.observe()`.
+ * One RO instance for the entire page. An element may have any number of
+ * subscribers; each receives every entry, and the element stays observed
+ * until the last one cleans up.
  *
- * @returns Cleanup function that unobserves the element.
+ * Per-element `box` options are forwarded to `ResizeObserver.observe()`. A
+ * single RO holds one observation per target, so when subscribers disagree on
+ * `box` the most recent call wins. Every entry carries all box sizes, so a
+ * subscriber can still read the box it cares about; only which box change
+ * triggers a notification is affected.
+ *
+ * @returns Cleanup function that removes this subscriber, unobserving the
+ * element once none remain.
  */
 export function observeResize(
   element: Element,
   callback: ROCallback,
   box?: ResizeObserverBoxOptions,
 ): () => void {
-  callbacks.set(element, callback);
+  let subscribers: Set<ROCallback> | undefined = callbacks.get(element);
+  if (!subscribers) {
+    subscribers = new Set();
+    callbacks.set(element, subscribers);
+  }
+  subscribers.add(callback);
   getObserver().observe(element, box ? { box } : undefined);
 
   let disposed = false;
@@ -24,12 +37,14 @@ export function observeResize(
     if (disposed) return;
     disposed = true;
 
-    // Only unobserve if our callback is still the registered one.
-    // A later subscription on the same element would have overwritten it.
-    if (callbacks.get(element) === callback) {
-      callbacks.delete(element);
-      observer?.unobserve(element);
-    }
+    const current: Set<ROCallback> | undefined = callbacks.get(element);
+    if (!current) return;
+
+    current.delete(callback);
+    if (current.size > 0) return;
+
+    callbacks.delete(element);
+    observer?.unobserve(element);
   };
 }
 
@@ -42,8 +57,14 @@ function getObserver(): ResizeObserver {
   if (!observer) {
     observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        const cb: ROCallback | undefined = callbacks.get(entry.target);
-        if (cb) cb(entry);
+        const subscribers: Set<ROCallback> | undefined = callbacks.get(
+          entry.target,
+        );
+        if (!subscribers) continue;
+        // Iterated directly rather than copied: this runs on every resize
+        // notification, and Set iteration already tolerates a subscriber
+        // removing itself, which is the reentrant case that actually happens.
+        for (const cb of subscribers) cb(entry);
       }
     });
   }

--- a/src/core/_internal/pool/ro-pool.ts
+++ b/src/core/_internal/pool/ro-pool.ts
@@ -6,8 +6,8 @@ const callbacks = new Map<Element, Set<ROCallback>>();
 /**
  * Observe an element via a singleton ResizeObserver.
  * One RO instance for the entire page. An element may have any number of
- * subscribers; each receives every entry, and the element stays observed
- * until the last one cleans up.
+ * subscribers; each receives every entry delivered after it subscribes, and
+ * the element stays observed until the last one cleans up.
  *
  * Per-element `box` options are forwarded to `ResizeObserver.observe()`. A
  * single RO holds one observation per target, so when subscribers disagree on

--- a/src/react/use-sight/index.spec.ts
+++ b/src/react/use-sight/index.spec.ts
@@ -275,3 +275,38 @@ describe('page target is SSR-safe', () => {
     expect(result.current.phaseRef.current).toBe('unknown');
   });
 });
+
+describe('shared element', () => {
+  it('two hooks watching one element both see it enter view', async () => {
+    // A reveal animation and a lazy-load trigger on the same node is ordinary
+    // composition; the pool must not let the later one silence the earlier.
+    const useSight = await getHook();
+    const { ref, el } = createRefWithElement();
+
+    const first = renderHook(() => useSight({ ref }));
+    const second = renderHook(() => useSight({ ref }));
+
+    act(() => {
+      mockIO.trigger(el, true);
+    });
+
+    expect(first.result.current.phase).toBe('visible');
+    expect(second.result.current.phase).toBe('visible');
+  });
+
+  it('unmounting one hook leaves the other watching', async () => {
+    const useSight = await getHook();
+    const { ref, el } = createRefWithElement();
+
+    const first = renderHook(() => useSight({ ref }));
+    const second = renderHook(() => useSight({ ref }));
+
+    second.unmount();
+
+    act(() => {
+      mockIO.trigger(el, true);
+    });
+
+    expect(first.result.current.phase).toBe('visible');
+  });
+});

--- a/src/react/use-size/index.spec.ts
+++ b/src/react/use-size/index.spec.ts
@@ -273,3 +273,38 @@ describe('useSize with onResize (transient mode)', () => {
     expect(onResize).toHaveBeenLastCalledWith({ width: 300, height: 150 });
   });
 });
+
+describe('shared element', () => {
+  it('two hooks observing one element both receive sizes', async () => {
+    // Two components measuring the same node through a shared ref is ordinary
+    // composition; the pool must not let the later one silence the earlier.
+    const useSize = await getHook();
+    const { ref, el } = createRefWithElement();
+
+    const first = renderHook(() => useSize({ ref }));
+    const second = renderHook(() => useSize({ ref }));
+
+    act(() => {
+      mockRO.trigger(el, 320, 240);
+    });
+
+    expect(first.result.current.size).toEqual({ width: 320, height: 240 });
+    expect(second.result.current.size).toEqual({ width: 320, height: 240 });
+  });
+
+  it('unmounting one hook leaves the other observing', async () => {
+    const useSize = await getHook();
+    const { ref, el } = createRefWithElement();
+
+    const first = renderHook(() => useSize({ ref }));
+    const second = renderHook(() => useSize({ ref }));
+
+    second.unmount();
+
+    act(() => {
+      mockRO.trigger(el, 500, 400);
+    });
+
+    expect(first.result.current.size).toEqual({ width: 500, height: 400 });
+  });
+});


### PR DESCRIPTION
## Problem

Two hooks watching the same element, and only one of them works. Both observer pools stored a single callback per element, so a second subscriber overwrote the first: measured on IO and RO alike, the earlier subscriber received 0 callbacks and the later one received 1. A reveal animation beside a lazy-load trigger, or two components measuring one container, and whichever mounted first goes silent with nothing to indicate why.

Cleanup was wrong the same way. The first subscriber's cleanup saw its callback was no longer registered and did nothing, leaving the element observed with no owner, while the second's unobserved it out from under whoever remained.

## How this solves it

Each pool holds a `Set` of subscribers per element, dispatches to all of them, and releases the element only once the last is gone. The MediaQueryList pool already worked this way, so the three now agree.

One shared suite now runs against all four pools, so the promises they make to subscribers are stated once rather than re-derived per pool. `mql-pool` and `dpr` had no coverage of those promises at all.

## Watch out

- **A component that mounts onto an element already in view never learns it is visible.** It stays in the `unknown` state until the element next moves, and on a page that does not scroll it stays there for good. Pinned as a test. Not a regression, the old code broke the other subscriber instead. The obvious fix, replaying the last known state when someone subscribes, would fire a callback before the caller can cancel it, so it needs its own PR.
- **Two components watching different scroll containers can get results for the wrong one.** The pool key treats every custom root as identical, so they share an observer built for whichever registered first. Pre-existing and untouched here, worse than the bug this fixes, and also wants its own PR.
- **The tests this replaces were labelled "ownership safety".** They described what happened on a collision rather than claiming it was desirable. If overwriting was intentional, this is the wrong fix.

Verified by mutation rather than by a green run: reverting both pools fails 8 tests, making `mql-pool` single-listener fails 2, and releasing `dpr` on the first unsubscribe instead of the last fails 3. `mql` and `dpr` pass unmodified.

Start with `io-pool.ts`, since `ro-pool.ts` is the same shape without the outer options key.

