### PR TITLE
skill: de-noise scanner golden harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ pnpm format            # Check formatting (oxfmt --check)
 pnpm format:fix        # Fix formatting (oxfmt)
 pnpm size              # Build and check bundle sizes (size-limit)
 pnpm size:readme       # Build and update README.md bundle size table
+pnpm goldens           # Regenerate scanner goldens and the audit sample
 pnpm validate          # Run typecheck, lint, format, test, and skill:check in parallel
 pnpm skill:check       # Verify every public export has a skill reference (drift guard)
 pnpm skill:build       # Regenerate skills/phase/metadata.json from SKILL.md
@@ -227,7 +228,7 @@ The audit scanner (`skills/phase/scripts/scan.mjs`) detects anti-pattern candida
    - **Severity is what it costs when real; execution is what it costs now.** The scanner classifies each JS finding as per-frame or incidental from the surrounding code and ranks accordingly, so a signal does not need a severity bump to be noticed in a hot path. Set severity for the worst case and let the ranking sort the rest.
 4. Probe, don't just read: run the scanner against a real repo (`node skills/phase/scripts/scan.mjs <path>`), hand-classify a sample of findings, and set the noise tier from what you observe. Record the provenance in the PR description.
 5. Add the row to audit.md's signal table. `pnpm skill:check` fails CI when the table or fix pointers drift from the catalog; `pnpm test` executes the examples and eval ground truth.
-6. If the signal fires on the planted-defect fixture (`skills/phase/evals/scenarios/audit-planted-defects/workspace`), regenerate the goldens (`scan.mjs workspace > expected-scan.txt`, `--json` likewise) and run `pnpm skill:build` (regenerates audit.md's sample block).
+6. If the signal fires on the planted-defect fixture (`skills/phase/evals/scenarios/audit-planted-defects/workspace`), run `pnpm goldens` to regenerate both goldens and audit.md's sample block in the required order.
 7. Run `pnpm format:fix && pnpm validate`.
 
 When a real-world audit failure surfaces (wrong recommendation, missed context), encode it as an eval scenario under `skills/phase/evals/scenarios/` (see `ssr-semantics-guard` for the pattern) so it can never regress silently. Put everything machine-checkable in the scenario's `scan.assertions` block (`required`, `requiredAbsent`, `context`): `src/__tests__/scan.spec.ts` executes those assertions against the fixture workspace on every run, so a claim recorded there is a gate, not a note. If a fixture workspace needs a `package.json`, keep it free of `scripts` and `dependencies`: pnpm's recursive runs discover nested projects, so a fixture script named `test` or `lint` would execute during `pnpm validate`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:fix": "oxfmt .",
     "size": "size-limit",
     "size:readme": "node scripts/update-size-table.mjs",
+    "goldens": "node scripts/skill/regen-goldens.mjs",
     "prepublishOnly": "pnpm build",
     "prepare": "lefthook install || true",
     "validate": "pnpm run --parallel '/^(typecheck|lint|format|test|skill:check)$/'",

--- a/scripts/skill/regen-goldens.mjs
+++ b/scripts/skill/regen-goldens.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..', '..');
+const scenario = join(
+  root,
+  'skills/phase/evals/scenarios/audit-planted-defects',
+);
+const scanner = join(root, 'skills/phase/scripts/scan.mjs');
+
+function scan(args) {
+  const run = spawnSync(process.execPath, [scanner, ...args, 'workspace'], {
+    cwd: scenario,
+    encoding: 'utf8',
+  });
+  if (run.status !== 0) {
+    process.stderr.write(run.stderr);
+    process.exit(run.status ?? 1);
+  }
+  return run.stdout;
+}
+
+const text = scan([]);
+const json = scan(['--json']);
+
+writeFileSync(join(scenario, 'expected-scan.txt'), text);
+writeFileSync(join(scenario, 'expected-scan.json'), json);
+
+const sync = spawnSync(
+  process.execPath,
+  [join(root, 'scripts/skill/sync-scan-docs.mjs')],
+  { stdio: 'inherit' },
+);
+process.exit(sync.status ?? 1);

--- a/skills/phase/scripts/scan-examples.d.mts
+++ b/skills/phase/scripts/scan-examples.d.mts
@@ -6,9 +6,13 @@
 
 import type { ScanExample } from './scan.d.mts';
 
+export interface SignalExample extends ScanExample {
+  testId?: string;
+}
+
 export interface SignalExamples {
-  match: ScanExample[];
-  noMatch: ScanExample[];
+  match: SignalExample[];
+  noMatch: SignalExample[];
 }
 
 export declare const SIGNAL_EXAMPLES: Record<string, SignalExamples>;

--- a/skills/phase/scripts/scan-examples.mjs
+++ b/skills/phase/scripts/scan-examples.mjs
@@ -329,9 +329,20 @@ export const SIGNAL_EXAMPLES = {
           "const coarse = window.matchMedia('(pointer: coarse)').matches;\n",
       },
       {
+        file: 'src/pointer.ts',
+        content:
+          "export function isCoarse() {\n  return window.matchMedia('(pointer: coarse)').matches;\n}\n",
+      },
+      {
+        file: 'src/pointer.ts',
+        content:
+          "const { matches } = window.matchMedia('(pointer: coarse)');\n",
+      },
+      {
         // Regression: a listener on an unrelated receiver is not evidence that
         // the snapshot above subscribed. Looking for listener vocabulary
         // anywhere in the file would report this.
+        testId: 'unrelated-listener',
         file: 'src/form.ts',
         content:
           "const coarse = window.matchMedia('(pointer: coarse)').matches;\nsetLayout(coarse);\ninput.addEventListener('change', onInput);\n",
@@ -438,9 +449,15 @@ export const SIGNAL_EXAMPLES = {
       {
         // A timeout that reschedules itself recurs like an interval, and keeps
         // firing off-screen the same way.
+        testId: 'slow-recurring-timeout',
         file: 'src/pulse.ts',
         content:
           'function step() {\n  node.style.opacity = nextOpacity();\n  timer = setTimeout(step, 1000);\n}\ntimer = setTimeout(step, 1000);\n',
+      },
+      {
+        file: 'src/pulse.ts',
+        content:
+          'const step = () => {\n  node.style.opacity = nextOpacity();\n  timer = setTimeout(step, 1000);\n};\nsetTimeout(step, 1000);\n',
       },
     ],
     noMatch: [
@@ -454,6 +471,7 @@ export const SIGNAL_EXAMPLES = {
       {
         // Regression: a one-shot timeout that ends a transition runs once and
         // stops. `js-opacity-transform` still covers the style write.
+        testId: 'one-shot-style-write',
         file: 'src/press.ts',
         content:
           "node.style.transform = 'scale(.98)';\nconst id = setTimeout(() => {\n  node.style.transform = '';\n}, 100);\n",
@@ -465,6 +483,11 @@ export const SIGNAL_EXAMPLES = {
         file: 'src/reveal.ts',
         content:
           "node.style.transform = 'translateY(0)';\nnode.addEventListener('transitionend', onDone, { once: true });\nconst fallback = setTimeout(onDone, 320);\n",
+      },
+      {
+        file: 'src/reset.ts',
+        content:
+          "function reset() {\n  el.style.opacity = '1';\n}\nsetTimeout(reset, 200);\n",
       },
     ],
   },

--- a/src/__tests__/scan.spec.ts
+++ b/src/__tests__/scan.spec.ts
@@ -46,6 +46,26 @@ interface CliRun {
   stderr: string;
 }
 
+function signalExample(
+  signal: string,
+  kind: 'match' | 'noMatch',
+  testId: string,
+) {
+  const examples = SIGNAL_EXAMPLES[signal];
+  if (!examples) throw new Error(`Missing scanner examples for ${signal}`);
+  const example = examples[kind].find(
+    (candidate) => candidate.testId === testId,
+  );
+  if (!example) {
+    throw new Error(`Missing ${kind} example ${testId} for ${signal}`);
+  }
+  return example;
+}
+
+function normalizeSkillVersion(result: Record<string, unknown>) {
+  return { ...result, skillVersion: '<normalized>' };
+}
+
 function runCli(
   args: string[],
   cwd: string = SCENARIO_DIR,
@@ -419,26 +439,15 @@ describe('media query subscription evidence', () => {
     );
   }
 
-  it.each([
-    "const mql = window.matchMedia('(pointer: coarse)');\nmql.addEventListener('change', onChange);\n",
-    "const mql = window.matchMedia('(pointer: coarse)');\nmql.addListener(onChange);\n",
-    "window.matchMedia('(pointer: coarse)').addEventListener('change', sync);\n",
-  ])('reports a MediaQueryList that something subscribes to', (content) => {
-    expect(subscriptions(content).length).toBeGreaterThan(0);
-  });
-
-  it.each([
-    "const coarse = window.matchMedia('(pointer: coarse)').matches;\n",
-    "export function isCoarse() {\n  return window.matchMedia('(pointer: coarse)').matches;\n}\n",
-    "const { matches } = window.matchMedia('(pointer: coarse)');\n",
-  ])('forbids a subscription claim for a snapshot read', (content) => {
-    expect(subscriptions(content)).toEqual([]);
-  });
-
   it('does not count a listener on an unrelated receiver', () => {
+    const example = signalExample(
+      'raw-matchmedia',
+      'noMatch',
+      'unrelated-listener',
+    );
     expect(
-      subscriptions(
-        "const coarse = window.matchMedia('(pointer: coarse)').matches;\ninput.addEventListener('change', onInput);\n",
+      scanFile(example.file, example.content).filter(
+        (finding) => finding.signal === 'raw-matchmedia',
       ),
     ).toEqual([]);
   });
@@ -458,22 +467,6 @@ describe('recurring timer evidence', () => {
     );
   }
 
-  it.each([
-    "setInterval(() => {\n  track.style.transform = 'translateX(' + offset + 'px)';\n}, 3000);\n",
-    'function step() {\n  node.style.opacity = nextOpacity();\n  timer = setTimeout(step, 1000);\n}\ntimer = setTimeout(step, 1000);\n',
-    'const step = () => {\n  node.style.opacity = nextOpacity();\n  timer = setTimeout(step, 1000);\n};\nsetTimeout(step, 1000);\n',
-  ])('reports intervals and self-rescheduling timeouts', (content) => {
-    expect(timers(content).length).toBeGreaterThan(0);
-  });
-
-  it.each([
-    "node.style.transform = 'scale(.98)';\nconst id = setTimeout(() => {\n  node.style.transform = '';\n}, 100);\n",
-    "node.style.transform = 'translateY(0)';\nnode.addEventListener('transitionend', onDone, { once: true });\nconst fallback = setTimeout(onDone, 320);\n",
-    "function reset() {\n  el.style.opacity = '1';\n}\nsetTimeout(reset, 200);\n",
-  ])('forbids a recurring claim for a one-shot timeout', (content) => {
-    expect(timers(content)).toEqual([]);
-  });
-
   it('does not let a one-shot timeout suppress an interval on the same line', () => {
     expect(
       timers(
@@ -483,16 +476,25 @@ describe('recurring timer evidence', () => {
   });
 
   it('still reports the style write behind a dropped timer finding', () => {
-    const signals = scanFile(
-      'src/a.ts',
-      "node.style.transform = 'scale(.98)';\nconst id = setTimeout(() => {\n  node.style.transform = '';\n}, 100);\n",
-    ).map((finding) => finding.signal);
+    const example = signalExample(
+      'background-animation',
+      'noMatch',
+      'one-shot-style-write',
+    );
+    const signals = scanFile(example.file, example.content).map(
+      (finding) => finding.signal,
+    );
     expect(signals).toContain('js-opacity-transform');
   });
 
   it('does not rank a slow recurring timer as per-frame', () => {
-    const found = timers(
-      'function step() {\n  node.style.opacity = nextOpacity();\n  timer = setTimeout(step, 1000);\n}\ntimer = setTimeout(step, 1000);\n',
+    const example = signalExample(
+      'background-animation',
+      'match',
+      'slow-recurring-timeout',
+    );
+    const found = scanFile(example.file, example.content).filter(
+      (finding) => finding.signal === 'background-animation',
     );
     expect(found.map((finding) => finding.execution)).not.toContain(
       'per-frame',
@@ -881,7 +883,9 @@ describe('scan CLI', () => {
     const run = runCli(['--json', 'workspace']);
     expect(run.status).toBe(0);
     const actual = JSON.parse(run.stdout);
-    expect(actual).toEqual(golden);
+    expect(normalizeSkillVersion(actual)).toEqual(
+      normalizeSkillVersion(golden),
+    );
     const metadata = JSON.parse(readFileSync(METADATA, 'utf8'));
     expect(actual.skillVersion).toBe(metadata.version);
   });


### PR DESCRIPTION
## Problem

Scanner behavior was encoded in both executable examples and hand-copied tests, while the JSON golden treated skill version bumps as behavioral changes. Regenerating the two goldens and their documentation sample also required an order-sensitive manual procedure.

## Approach

This makes scanner examples the single source for detector-specific tests, with stable `testId` metadata where stronger assertions need a particular case. JSON golden comparison now normalizes `skillVersion` while independently verifying the live metadata version, and `pnpm goldens` regenerates both outputs before syncing the audit sample.

This is the first harness-focused slice of the scanner and audit restructure.

Closes DSN-1989