### PR TITLE
skill: add scanner seam-level test suites

### DIFF
--- a/scanner/__tests__/analysis.spec.ts
+++ b/scanner/__tests__/analysis.spec.ts
@@ -207,3 +207,51 @@ describe('analysis evidence registry', () => {
     ).toBe(true);
   });
 });
+
+describe('analysis', () => {
+  it('identifies self-recursive rAF ownership by line', () => {
+    const analysis = analysisOf(
+      'function tick() {\n  requestAnimationFrame(tick);\n}\nrequestAnimationFrame(tick);',
+    );
+
+    expect([...analysis.raf.recurringScheduleLines]).toEqual([1, 3]);
+    expect([...analysis.raf.recurringCallbackLines]).toEqual([0, 1, 2]);
+  });
+
+  it('identifies mutually recursive scheduled callbacks', () => {
+    const analysis = analysisOf(
+      'function first() { requestAnimationFrame(second); }\nfunction second() { requestAnimationFrame(first); }\nrequestAnimationFrame(first);',
+    );
+
+    expect([...analysis.raf.recurringScheduleLines]).toEqual([0, 1, 2]);
+    expect([...analysis.raf.recurringCallbackLines]).toEqual([0, 1]);
+  });
+
+  it('does not classify a named one-shot callback as recurring', () => {
+    const analysis = analysisOf(
+      'function initialize() { mount(); }\nrequestAnimationFrame(initialize);',
+    );
+
+    expect(analysis.raf.recurringScheduleLines).toEqual(new Set());
+    expect(analysis.raf.recurringCallbackLines).toEqual(new Set());
+  });
+
+  it('reports only MediaQueryLists that are subscribed', () => {
+    const analysis = analysisOf(
+      "const snapshot = matchMedia('(hover: hover)').matches;\nconst query = matchMedia('(min-width: 48em)');\nquery.addEventListener('change', update);",
+    );
+
+    expect(analysis.subscribedMediaQueries).toEqual(new Set([1]));
+  });
+
+  it('maps intrinsic move props to their named handler lines', () => {
+    const analysis = analysisOf(
+      'function move() {\n  const width = target.offsetWidth;\n}\n<div onPointerMove={move} />;',
+    );
+
+    expect(analysis.moveHandlers.propRanges).toEqual(
+      new Map([[3, { start: 0, end: 2 }]]),
+    );
+    expect(analysis.moveHandlers.handlerLines).toEqual(new Set([0, 1, 2]));
+  });
+});

--- a/scanner/__tests__/context.spec.ts
+++ b/scanner/__tests__/context.spec.ts
@@ -2,7 +2,90 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import {
+  detectAppRouterRoot,
+  detectProjectRoot,
+  updateContext,
+} from '../context.ts';
+import type { ScanContext } from '../context.ts';
 import { scanTargets } from '../index.ts';
+
+function emptyContext(): ScanContext {
+  return {
+    framework: null,
+    appRouter: false,
+    ppr: false,
+    clientComponents: 0,
+    evidence: [],
+  };
+}
+
+describe('context', () => {
+  it('sets framework and App Router from an app-root path', () => {
+    const context = emptyContext();
+
+    updateContext('app/dashboard/page.tsx', '', context, 'page.tsx', 'app');
+
+    expect(context).toEqual({
+      framework: 'next',
+      appRouter: true,
+      ppr: false,
+      clientComponents: 0,
+      evidence: ['page.tsx'],
+    });
+  });
+
+  it('sets framework and PPR from a route-segment export', () => {
+    const context = emptyContext();
+
+    updateContext(
+      'routes/page.tsx',
+      'export const experimental_ppr = true;',
+      context,
+      'page.tsx',
+    );
+
+    expect(context.framework).toBe('next');
+    expect(context.appRouter).toBe(false);
+    expect(context.ppr).toBe(true);
+    expect(context.evidence).toEqual(['page.tsx']);
+  });
+
+  it('counts client components without inferring a framework', () => {
+    const context = emptyContext();
+
+    updateContext('components/chart.tsx', "'use client';", context);
+
+    expect(context.framework).toBe(null);
+    expect(context.clientComponents).toBe(1);
+  });
+
+  it('does not treat an app-root prefix collision as App Router context', () => {
+    const context = emptyContext();
+    updateContext('application/page.tsx', '', context, 'page.tsx', 'app');
+    expect(context.appRouter).toBe(false);
+  });
+
+  it('detects project and router roots with thin filesystem fixtures', () => {
+    const root = mkdtempSync(join(tmpdir(), 'phase-context-'));
+    try {
+      mkdirSync(join(root, 'src', 'app', 'dashboard'), { recursive: true });
+      writeFileSync(
+        join(root, 'next.config.ts'),
+        'export default { cacheComponents: true };',
+      );
+      writeFileSync(join(root, 'src', 'app', 'dashboard', 'page.tsx'), '');
+      const context = emptyContext();
+
+      expect(detectProjectRoot(join(root, 'src', 'app'), context)).toBe(root);
+      expect(context.framework).toBe('next');
+      expect(context.ppr).toBe(true);
+      expect(detectAppRouterRoot(root)).toBe('src/app');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('environment context', () => {
   it('detects Next.js App Router and PPR from the ssr-semantics workspace', () => {

--- a/scanner/__tests__/detect.spec.ts
+++ b/scanner/__tests__/detect.spec.ts
@@ -1,0 +1,136 @@
+import { newDiag, scanFile } from '../detect.ts';
+import { parseSuppressionDirective } from '../lex.ts';
+
+function forcedReflow(content: string) {
+  return scanFile('src/example.ts', content).find(
+    (candidate) => candidate.signal === 'forced-reflow',
+  );
+}
+
+function contentAtDriverDistance(distance: number): string {
+  return [
+    'onTick(() => {});',
+    ...Array.from({ length: distance - 1 }, () => ''),
+    'const width = target.offsetWidth;',
+  ].join('\n');
+}
+
+describe('executionOf', () => {
+  it('classifies recurring callback and schedule lines as per-frame', () => {
+    expect(
+      forcedReflow(
+        'function tick() {\n  const width = target.offsetWidth;\n  requestAnimationFrame(tick);\n}\nrequestAnimationFrame(tick);',
+      )?.execution,
+    ).toBe('per-frame');
+  });
+
+  it('classifies move-handler bodies and prop lines as per-frame', () => {
+    expect(
+      forcedReflow(
+        'function move() {\n  const width = target.offsetWidth;\n}\n<div onPointerMove={move} />;',
+      )?.execution,
+    ).toBe('per-frame');
+  });
+
+  it('includes the FRAME_DRIVER window boundary but not the next line', () => {
+    expect(forcedReflow(contentAtDriverDistance(5))?.execution).toBe(
+      'per-frame',
+    );
+    expect(forcedReflow(contentAtDriverDistance(6))?.execution).toBe(
+      'per-frame',
+    );
+    expect(forcedReflow(contentAtDriverDistance(7))?.execution).toBe(
+      'incidental',
+    );
+  });
+
+  it('does not classify stylesheet execution', () => {
+    const finding = scanFile(
+      'src/example.css',
+      '.x { transition: all 1s; }',
+    )[0];
+    expect(finding?.execution).toBe(null);
+  });
+});
+
+describe('dedup/supersedes', () => {
+  it('keeps the specific finding and removes its same-line general finding', () => {
+    const findings = scanFile(
+      'src/example.ts',
+      'function tick() {\n  setReady(true);\n  requestAnimationFrame(tick);\n}\nrequestAnimationFrame(tick);',
+    );
+
+    expect(
+      findings
+        .filter((candidate) => candidate.signal === 'setstate-in-raf')
+        .map((candidate) => candidate.line),
+    ).toEqual([3, 5]);
+    expect(
+      findings.filter((candidate) => candidate.signal === 'manual-raf'),
+    ).toEqual([]);
+  });
+
+  it('keeps the general finding when the superseding finding never matched', () => {
+    const findings = scanFile(
+      'src/example.ts',
+      'function tick() {\n  render();\n  requestAnimationFrame(tick);\n}\nrequestAnimationFrame(tick);',
+    );
+
+    expect(
+      findings.filter((candidate) => candidate.signal === 'manual-raf'),
+    ).toHaveLength(2);
+    expect(
+      findings.filter((candidate) => candidate.signal === 'setstate-in-raf'),
+    ).toEqual([]);
+  });
+});
+
+describe('suppressions', () => {
+  it('parses the supported grammar and rejects unrelated comments', () => {
+    expect(
+      parseSuppressionDirective(
+        'phase-scan-ignore: manual-raf -- accepted ownership',
+      ),
+    ).toEqual({ signalId: 'manual-raf', reason: 'accepted ownership' });
+    expect(parseSuppressionDirective('// ordinary comment')).toBe(null);
+  });
+
+  it('suppresses the directive line and the next line only', () => {
+    const diag = newDiag();
+    const findings = scanFile(
+      'src/anim.ts',
+      'function tick() {\n  /* phase-scan-ignore manual-raf -- accepted */ requestAnimationFrame(tick);\n  requestAnimationFrame(tick);\n  requestAnimationFrame(tick);\n}',
+      diag,
+    ).filter((candidate) => candidate.signal === 'manual-raf');
+
+    expect(findings.map((candidate) => candidate.line)).toEqual([4]);
+    expect(diag.suppressed).toBe(2);
+  });
+
+  it('does not count a dangling per-file directive', () => {
+    const diag = newDiag();
+    scanFile(
+      'src/anim.ts',
+      '// phase-scan-ignore missing-reduced-motion -- accepted\nconst ready = true;',
+      diag,
+    );
+
+    expect(diag.suppressed).toBe(0);
+  });
+
+  it('applies a per-file directive wherever its finding occurs', () => {
+    const diag = newDiag();
+    const findings = scanFile(
+      'src/anim.ts',
+      'function tick() { requestAnimationFrame(tick); }\n// phase-scan-ignore missing-reduced-motion -- accepted',
+      diag,
+    );
+
+    expect(
+      findings.some(
+        (candidate) => candidate.signal === 'missing-reduced-motion',
+      ),
+    ).toBe(false);
+    expect(diag.suppressed).toBe(1);
+  });
+});

--- a/scanner/__tests__/render.spec.ts
+++ b/scanner/__tests__/render.spec.ts
@@ -9,8 +9,8 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { ScanFinding } from '../index.ts';
-import { formatText, scanFile } from '../index.ts';
+import type { ScanFinding, ScanResult } from '../index.ts';
+import { formatJson, formatText, scanFile } from '../index.ts';
 
 const SCRIPT = join(process.cwd(), 'skills/phase/scripts/scan.mjs');
 const SCENARIO_DIR = join(
@@ -22,6 +22,48 @@ interface CliRun {
   status: number;
   stdout: string;
   stderr: string;
+}
+
+function findingOf(
+  file: string,
+  line: number,
+  execution: ScanFinding['execution'] = 'incidental',
+): ScanFinding {
+  return {
+    signal: 'forced-reflow',
+    severity: 'critical',
+    noise: 'precise',
+    execution,
+    file,
+    line,
+    text: 'const width = target.offsetWidth;',
+    fix: 'references/use-size.md',
+  };
+}
+
+function resultOf(findings: ScanFinding[]): ScanResult {
+  return {
+    targets: ['src'],
+    filesScanned: 1,
+    filesSkipped: {
+      excluded: 0,
+      unsupported: 0,
+      generated: 0,
+      unreadable: 0,
+      unreadableDirs: 0,
+    },
+    linesSkipped: 0,
+    findings,
+    suppressed: 0,
+    warnings: [],
+    context: {
+      framework: null,
+      appRouter: false,
+      ppr: false,
+      clientComponents: 0,
+      evidence: [],
+    },
+  };
 }
 
 function runCli(
@@ -37,29 +79,86 @@ function runCli(
   return { status: run.status ?? -1, stdout: run.stdout, stderr: run.stderr };
 }
 
+describe('render', () => {
+  it('caps a signal listing at twenty hand-built findings', () => {
+    const findings = Array.from({ length: 21 }, (_, index) =>
+      findingOf(`src/file-${index}.ts`, index + 1),
+    );
+    const text = formatText(resultOf(findings));
+
+    expect((text.match(/src\/file-\d+\.ts:/g) ?? []).length).toBe(20);
+    expect(text).toContain('and 1 more');
+  });
+
+  it('caps each file at four entries without hiding other files', () => {
+    const findings = [
+      ...Array.from({ length: 6 }, (_, index) =>
+        findingOf('src/busy.ts', index + 1),
+      ),
+      findingOf('src/other.ts', 1),
+    ];
+    const text = formatText(resultOf(findings));
+
+    expect((text.match(/src\/busy\.ts:/g) ?? []).length).toBe(4);
+    expect(text).toContain('src/other.ts:1');
+  });
+
+  it('orders per-frame findings first and labels only mixed execution groups', () => {
+    const mixed = formatText(
+      resultOf([
+        findingOf('src/cold.ts', 1),
+        findingOf('src/hot.ts', 2, 'per-frame'),
+      ]),
+    );
+    const allHot = formatText(
+      resultOf([findingOf('src/hot.ts', 2, 'per-frame')]),
+    );
+
+    expect(mixed.indexOf('src/hot.ts')).toBeLessThan(
+      mixed.indexOf('src/cold.ts'),
+    );
+    expect(mixed).toContain('↑ in a per-frame path:');
+    expect(mixed).toContain('· elsewhere:');
+    expect(allHot).not.toContain('↑ in a per-frame path:');
+  });
+
+  it('shows hotspots only once the report reaches the threshold', () => {
+    const four = Array.from({ length: 4 }, (_, index) =>
+      findingOf(index < 2 ? 'src/busy.ts' : `src/${index}.ts`, index + 1),
+    );
+    const five = [...four, findingOf('src/other.ts', 5)];
+
+    expect(formatText(resultOf(four))).not.toContain('## hotspots');
+    expect(formatText(resultOf(five))).toContain('## hotspots');
+  });
+
+  it('limits returned JSON without changing full-result summary counts', () => {
+    const json = formatJson(
+      resultOf([
+        findingOf('src/a.ts', 1, 'per-frame'),
+        findingOf('src/a.ts', 2),
+        findingOf('src/b.ts', 1),
+      ]),
+      1,
+    );
+
+    expect(json.findings).toHaveLength(1);
+    expect(json.summary).toMatchObject({
+      total: 3,
+      sites: 3,
+      returned: 1,
+      actionable: 3,
+      perFrame: 1,
+      bySeverity: { critical: 3, high: 0, medium: 0 },
+    });
+    expect(json.hotspots).toEqual([{ file: 'src/a.ts', count: 2 }]);
+  });
+});
+
 describe('output', () => {
   function render(findings: ScanFinding[], overrides = {}) {
     return formatText({
-      targets: ['.'],
-      filesScanned: 1,
-      filesSkipped: {
-        excluded: 0,
-        unsupported: 0,
-        generated: 0,
-        unreadable: 0,
-        unreadableDirs: 0,
-      },
-      linesSkipped: 0,
-      findings,
-      suppressed: 0,
-      warnings: [],
-      context: {
-        framework: null,
-        appRouter: false,
-        ppr: false,
-        clientComponents: 0,
-        evidence: [],
-      },
+      ...resultOf(findings),
       ...overrides,
     });
   }

--- a/scanner/__tests__/walk.spec.ts
+++ b/scanner/__tests__/walk.spec.ts
@@ -1,0 +1,85 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { newDiag, scanTargets } from '../index.ts';
+import { toPathMatcher, walk } from '../walk.ts';
+
+describe('walk/toPathMatcher', () => {
+  it('matches plain patterns as substrings, including in absolute paths', () => {
+    const matches = toPathMatcher('test');
+    expect(matches('/tmp/contest/src/file.ts')).toBe(true);
+    expect(matches('/tmp/source/src/file.ts')).toBe(false);
+  });
+
+  it('keeps single wildcards within a segment and double wildcards recursive', () => {
+    expect(toPathMatcher('src/*.ts')('src/file.ts')).toBe(true);
+    expect(toPathMatcher('src/*.ts')('src/nested/file.ts')).toBe(false);
+    expect(toPathMatcher('src/**/file.ts')('src/file.ts')).toBe(true);
+    expect(toPathMatcher('src/**/file.ts')('src/nested/deep/file.ts')).toBe(
+      true,
+    );
+  });
+
+  it('applies slash-free globs to the basename', () => {
+    const matches = toPathMatcher('*.spec.ts');
+    expect(matches('/tmp/project/src/example.spec.ts')).toBe(true);
+    expect(matches('/tmp/project/src/example.ts')).toBe(false);
+  });
+
+  it('walks supported files in stable order while skipping generated files and directories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'phase-walk-'));
+    try {
+      mkdirSync(join(root, 'src'));
+      mkdirSync(join(root, 'node_modules'));
+      writeFileSync(join(root, 'z.ts'), '');
+      writeFileSync(join(root, 'a.css'), '');
+      writeFileSync(join(root, 'types.d.ts'), '');
+      writeFileSync(join(root, 'bundle.min.js'), '');
+      writeFileSync(join(root, 'README.md'), '');
+      writeFileSync(join(root, 'src', 'b.tsx'), '');
+      writeFileSync(join(root, 'node_modules', 'ignored.ts'), '');
+      symlinkSync(join(root, 'src'), join(root, 'linked'));
+
+      const files = walk(root, newDiag()).map((file) =>
+        file.slice(root.length + 1),
+      );
+      expect(files).toEqual(['a.css', 'src/b.tsx', 'z.ts']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('pins generated and excluded behavior for directory and file targets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'phase-targets-'));
+    try {
+      mkdirSync(join(root, '__tests__'));
+      const generated = join(root, 'types.d.ts');
+      const excluded = join(root, '__tests__', 'example.ts');
+      writeFileSync(generated, 'requestAnimationFrame(tick);');
+      writeFileSync(excluded, 'requestAnimationFrame(tick);');
+
+      const directory = scanTargets([root]);
+      const generatedFile = scanTargets([generated]);
+      const excludedFile = scanTargets([excluded]);
+
+      expect(directory.filesScanned).toBe(0);
+      expect(directory.filesSkipped.generated).toBe(0);
+      expect(directory.filesSkipped.excluded).toBe(1);
+      expect(generatedFile.filesSkipped.generated).toBe(1);
+      expect(generatedFile.filesSkipped.excluded).toBe(0);
+      expect(excludedFile.filesSkipped.excluded).toBe(1);
+      expect(excludedFile.filesSkipped.generated).toBe(0);
+      expect(generatedFile.findings).toEqual([]);
+      expect(excludedFile.findings).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Scanner failures were only observable through whole-file scans, so a failed test could not distinguish analysis, classification, suppression, deduplication, or rendering regressions. This made the scanner internals harder to change safely.

This adds focused suites for the seven scanner seams while retaining the existing composition tests and goldens. Private execution and deduplication behavior stays behind the existing `scanFile` interface rather than expanding production module contracts.

This is step 7 of 9 in the scanner restructure. A local mutation check that inverted the dedup survivor branch failed the named `dedup/supersedes` suite, confirming the new layer catches the intended internal regression.

Closes DSN-1995