### PR TITLE
test(cli): stop the pack-and-install spec flaking on slow runners

### DIFF
--- a/packages/cli/cli.spec.ts
+++ b/packages/cli/cli.spec.ts
@@ -168,5 +168,5 @@ describe('phase command distribution', () => {
       'read: https://github.com/vercel-labs/phase/blob/main/skills/phase/references/',
     );
     expect(scan.stdout).not.toMatch(/(?:read: |\()references\//);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
The pack-and-install spec spawns npm twice (`npm pack`, then `npm install` of the tarball) plus three runs of the installed command, all under vitest's default 5-second timeout. On GitHub-hosted runners that budget is borderline: it took 5.7s and failed the docs-only #81, while every run on main has passed. Locally the same spec finishes in under a second.

The spec now declares a 30-second timeout, sized for subprocess work on a slow runner rather than for in-process assertions. No behavior under test changes.
