### PR TITLE
ci: publish declared package deltas [DSN-2069]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 # Validates every push to main and publishes versions not yet present on npm.
 # Uses npm Trusted Publishing (OIDC) -- no NPM_TOKEN secret needed.
-# Requires the package to be configured as a Trusted Publisher on npmjs.com
-# linked to this repo and workflow.
+# Requires every declared package to be configured as a Trusted Publisher on
+# npmjs.com linked to this repo and workflow, with Environment left blank and
+# direct `npm publish` allowed.
 # Existing versions are successful no-ops; PR CI requires package-affecting
 # changes to include a version bump.
 
@@ -20,8 +21,29 @@ permissions:
   contents: read
 
 jobs:
-  # Re-run the full validation gate on the merge commit before doing anything
-  # release-related. Branch protection covers the PR's HEAD, but flaky tests,
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      packages: ${{ steps.releases.outputs.packages }}
+      has_packages: ${{ steps.releases.outputs.has_packages }}
+
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Detect unpublished package versions
+        id: releases
+        run: node scripts/detect-package-releases.mjs >> "$GITHUB_OUTPUT"
+
+  # Re-run the full validation gate on the merge commit before publishing.
+  # Branch protection covers the PR's HEAD, but flaky tests,
   # dep drift, or admin merges can let a broken commit land on main. Anything
   # publish-worthy must pass these checks first. This job has no id-token.
   validate:
@@ -97,52 +119,83 @@ jobs:
       - name: Run browser tests
         run: pnpm test:browser
 
-  # Minimal publish job. Only this job holds id-token: write, and it runs only
-  # after validation succeeds. npm publish triggers `prepublishOnly` (pnpm
-  # build), so the package is rebuilt here from a clean checkout before
-  # publishing.
+  # Minimal publish job. Each package is rebuilt and packed from a clean
+  # checkout. Only these serialized matrix legs hold id-token: write.
   publish:
-    needs: [validate, browser]
+    needs: [validate, browser, detect]
+    if: needs.detect.outputs.has_packages == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write
+    strategy:
+      max-parallel: 1
+      matrix:
+        package: ${{ fromJSON(needs.detect.outputs.packages) }}
 
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-        with:
-          fetch-depth: 0
-          lfs: true
-
-      - uses: pnpm/action-setup@fdbc4fdcf7d143a5d0a39e9a02e103b13e309024 # v6.0.4
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "24"
-          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
-      - name: Check npm version
-        id: release
-        run: |
-          NAME=$(node -p "require('./packages/phase/package.json').name")
-          VERSION=$(node -p "require('./packages/phase/package.json').version")
-          PUBLISHED_VERSIONS=$(npm view "$NAME" versions --json)
+      - name: Recheck unpublished package version
+        id: recheck
+        env:
+          PACKAGE_DIR: ${{ matrix.package }}
+        run: node scripts/detect-package-releases.mjs "$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
 
-          if VERSION="$VERSION" node -e \
-            "const v = JSON.parse(require('node:fs').readFileSync(0, 'utf8')); process.exit((Array.isArray(v) ? v : [v]).includes(process.env.VERSION) ? 0 : 1)" \
-            <<< "$PUBLISHED_VERSIONS"; then
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping npm publish: $NAME@$VERSION already exists."
-          else
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-            echo "Publishing $NAME@$VERSION."
-          fi
+      - if: steps.recheck.outputs.has_packages == 'true'
+        uses: pnpm/action-setup@fdbc4fdcf7d143a5d0a39e9a02e103b13e309024 # v6.0.4
 
       - name: Install dependencies
-        if: steps.release.outputs.should_publish == 'true'
+        if: steps.recheck.outputs.has_packages == 'true'
         run: pnpm install --frozen-lockfile
 
+      # npm@11 can leave sigstore missing when it replaces the bundled npm in
+      # place. Verify libnpmpublish can resolve it, retry once, then fail before
+      # a publish starts.
+      - name: Install a provenance-capable npm
+        if: steps.recheck.outputs.has_packages == 'true'
+        run: |
+          set -eo pipefail
+          verify_sigstore() {
+            node -e "require.resolve('sigstore', { paths: ['$(npm root -g)/npm/node_modules/libnpmpublish/lib'] })"
+          }
+          npm install -g npm@11 --force --registry=https://registry.npmjs.org
+          npm --version
+          if ! verify_sigstore; then
+            echo "::warning::sigstore unresolved after npm upgrade; reinstalling"
+            npm install -g npm@11 --force --registry=https://registry.npmjs.org
+            verify_sigstore
+          fi
+          echo "::notice::npm $(npm --version) ready with provenance support (sigstore resolves)"
+
+      - name: Build package
+        if: steps.recheck.outputs.has_packages == 'true'
+        env:
+          PACKAGE_DIR: ${{ matrix.package }}
+        run: pnpm exec turbo run build --filter="./$PACKAGE_DIR"
+
+      # pnpm rewrites workspace dependency ranges while packing. npm performs
+      # the OIDC exchange and provenance generation when publishing the tarball.
+      - name: Pack package
+        if: steps.recheck.outputs.has_packages == 'true'
+        env:
+          PACKAGE_DIR: ${{ matrix.package }}
+        run: pnpm --dir "$PACKAGE_DIR" pack --out "$RUNNER_TEMP/package.tgz"
+
+      - name: Verify packed package name and version
+        if: steps.recheck.outputs.has_packages == 'true'
+        env:
+          EXPECTED_PACKAGE_NAME: ${{ steps.recheck.outputs.package_name }}
+          EXPECTED_PACKAGE_VERSION: ${{ steps.recheck.outputs.package_version }}
+        run: tar -xOf "$RUNNER_TEMP/package.tgz" package/package.json | node scripts/verify-packed-package.mjs
+
       - name: Publish to npm
-        if: steps.release.outputs.should_publish == 'true'
-        working-directory: packages/phase
-        run: npm publish
+        if: steps.recheck.outputs.has_packages == 'true'
+        run: npm publish "$RUNNER_TEMP/package.tgz" --access public --provenance --registry=https://registry.npmjs.org --@usephase:registry=https://registry.npmjs.org

--- a/docs/adr/0021-decouple-github-release-protection-from-npm-identity.md
+++ b/docs/adr/0021-decouple-github-release-protection-from-npm-identity.md
@@ -1,0 +1,13 @@
+# Decouple GitHub release protection from npm identity
+
+## Context
+
+GitHub environment protection is an operational control that may change as release risk changes. Each npm trusted-publisher configuration binds a package to a repository, workflow, and optional GitHub environment. The configuration cannot be edited after creation, so changing the environment match requires deleting and recreating it.
+
+## Decision
+
+Publish jobs use the `release` GitHub environment, while every npm trusted-publisher configuration leaves its optional Environment field blank and explicitly allows direct `npm publish`.
+
+## Reason
+
+GitHub can add or remove reviewers without changing npm's OIDC identity configuration. npm still restricts publication to this repository and top-level workflow, while GitHub owns the adjustable approval gate.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "test:browser": "turbo run test:browser",
-    "test:root": "vitest run --globals scripts/check-package-version.spec.mjs",
+    "test:root": "vitest run --globals scripts/*.spec.mjs",
     "typecheck": "turbo run typecheck",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",

--- a/scripts/check-package-version.mjs
+++ b/scripts/check-package-version.mjs
@@ -1,5 +1,11 @@
-import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { posix } from 'node:path';
+
+import { readPublishablePackages } from './publishable-packages.mjs';
+import {
+  compareSemanticVersions,
+  isSemanticVersion,
+} from './semantic-version.mjs';
 
 const base = process.argv[2];
 
@@ -7,24 +13,9 @@ if (!base) {
   throw new Error('Usage: node scripts/check-package-version.mjs <base-ref>');
 }
 
-const currentPackage = JSON.parse(
-  readFileSync('packages/phase/package.json', 'utf8'),
-);
-
-let basePackagePath = 'packages/phase/package.json';
-try {
-  execFileSync('git', ['cat-file', '-e', `${base}:${basePackagePath}`], {
-    stdio: 'ignore',
-  });
-} catch {
-  basePackagePath = 'package.json';
-}
-const workspaceMigration = basePackagePath === 'package.json';
-const basePackage = JSON.parse(
-  execFileSync('git', ['show', `${base}:${basePackagePath}`], {
-    encoding: 'utf8',
-  }),
-);
+execFileSync('git', ['rev-parse', '--verify', `${base}^{commit}`], {
+  stdio: 'ignore',
+});
 
 const diffTokens = execFileSync(
   'git',
@@ -42,48 +33,14 @@ for (let index = 0; index < diffTokens.length; ) {
   changedFiles.push({ status, source, file });
 }
 
-// Tests and mocks never ship: the build bundles only the three barrel entry
-// points, and the published files are dist/LICENSE/README.md. A spec-only
-// change must not demand a version bump for an identical package.
 const TEST_ONLY = /\.spec\.|\.test\.|__tests__\/|__mocks__\//;
-const isPackageBuildInput = (path) =>
-  path &&
-  (((path.startsWith('packages/phase/src/') ||
-    (workspaceMigration && path.startsWith('src/'))) &&
-    !TEST_ONLY.test(path)) ||
-    path === 'packages/phase/tsconfig.json' ||
-    path === 'packages/phase/tsdown.config.ts' ||
-    path === 'tsconfig.base.json' ||
-    (workspaceMigration && path === 'tsdown.config.ts'));
-
-const packageSourceChanged = changedFiles.some(({ status, source, file }) => {
-  if (!file) return false;
-  if (
-    workspaceMigration &&
-    status === 'R100' &&
-    ((source?.startsWith('src/') && file === `packages/phase/${source}`) ||
-      (source === 'tsdown.config.ts' &&
-        file === 'packages/phase/tsdown.config.ts'))
-  ) {
-    return false;
-  }
-  if (
-    workspaceMigration &&
-    status === 'A' &&
-    (file === 'packages/phase/tsconfig.json' || file === 'tsconfig.base.json')
-  ) {
-    return false;
-  }
-  return [source, file].some(isPackageBuildInput);
-});
-
 const publishedManifestFields = [
-  'name',
   'description',
   'author',
   'license',
   'repository',
   'publishConfig',
+  'bin',
   'type',
   'sideEffects',
   'dependencies',
@@ -95,22 +52,155 @@ const publishedManifestFields = [
   'exports',
   'engines',
 ];
+const publishedScriptFields = [
+  'prebuild',
+  'build',
+  'postbuild',
+  'prepublish',
+  'prepublishOnly',
+  'prepack',
+  'prepare',
+  'postpack',
+  'preinstall',
+  'install',
+  'postinstall',
+  'publish',
+  'postpublish',
+];
 
-const publishedManifestChanged = publishedManifestFields.some(
-  (field) =>
-    JSON.stringify(currentPackage[field]) !==
-    JSON.stringify(basePackage[field]),
-);
+function readBaseFile(path) {
+  const exists =
+    spawnSync('git', ['cat-file', '-e', `${base}:${path}`]).status === 0;
+  if (!exists) return;
+  return execFileSync('git', ['show', `${base}:${path}`], { encoding: 'utf8' });
+}
 
-if (!packageSourceChanged && !publishedManifestChanged) {
-  console.log('No package release required.');
-} else if (currentPackage.version === basePackage.version) {
-  throw new Error(
-    `Package contents changed without a version bump (still ${currentPackage.version}). ` +
-      'Bump packages/phase/package.json and update CHANGELOG.md before merging this package release.',
+function isPackageBuildInput(path, directory) {
+  return (
+    path === 'tsconfig.base.json' ||
+    path === `${directory}/tsconfig.json` ||
+    path === `${directory}/tsdown.config.ts` ||
+    (path?.startsWith(`${directory}/src/`) && !TEST_ONLY.test(path))
   );
-} else {
+}
+
+const errors = [];
+const baseDeclaration = readBaseFile('scripts/publishable-packages.json');
+const basePackages = baseDeclaration
+  ? JSON.parse(baseDeclaration).map((directory) => {
+      const manifest = readBaseFile(`${directory}/package.json`);
+      if (!manifest) {
+        throw new Error(
+          `Declared package ${directory} has no manifest at ${base}`,
+        );
+      }
+      return { directory, manifest: JSON.parse(manifest) };
+    })
+  : [];
+
+for (const {
+  directory,
+  manifest: currentPackage,
+} of readPublishablePackages()) {
+  const manifestPath = `${directory}/package.json`;
+  const directBaseManifest = readBaseFile(manifestPath);
+  let basePackageEntry;
+  if (directBaseManifest) {
+    const manifest = JSON.parse(directBaseManifest);
+    if (manifest.name === currentPackage.name) {
+      basePackageEntry = { directory, manifest };
+    }
+  }
+  basePackageEntry ??= basePackages.find(
+    ({ manifest }) => manifest.name === currentPackage.name,
+  );
+  if (!basePackageEntry) {
+    const manifestRename = changedFiles.find(
+      ({ source, file }) =>
+        file === manifestPath && source?.endsWith('/package.json'),
+    );
+    if (manifestRename?.source) {
+      const manifest = JSON.parse(
+        readBaseFile(manifestRename.source) ?? 'null',
+      );
+      if (manifest?.name === currentPackage.name) {
+        basePackageEntry = {
+          directory: posix.dirname(manifestRename.source),
+          manifest,
+        };
+      }
+    }
+  }
+  if (!basePackageEntry) {
+    console.log(
+      `Package release requested for ${currentPackage.name}: new package at ${currentPackage.version}.`,
+    );
+    continue;
+  }
+
+  const { directory: baseDirectory, manifest: basePackage } = basePackageEntry;
+  const baseManifestPath = `${baseDirectory}/package.json`;
+  const packageSourceChanged = changedFiles.some(({ status, source, file }) => {
+    const unchangedMove =
+      baseDirectory !== directory &&
+      status === 'R100' &&
+      source?.startsWith(`${baseDirectory}/`) &&
+      file?.startsWith(`${directory}/`) &&
+      source.slice(baseDirectory.length) === file.slice(directory.length);
+    if (unchangedMove) return false;
+
+    return [source, file].some(
+      (path) =>
+        isPackageBuildInput(path, directory) ||
+        isPackageBuildInput(path, baseDirectory),
+    );
+  });
+  const publishedManifestChanged = publishedManifestFields.some(
+    (field) =>
+      JSON.stringify(currentPackage[field]) !==
+      JSON.stringify(basePackage[field]),
+  );
+  const publishedScriptChanged = publishedScriptFields.some(
+    (field) => currentPackage.scripts?.[field] !== basePackage.scripts?.[field],
+  );
+  const versionChanged = currentPackage.version !== basePackage.version;
+
+  if (
+    !packageSourceChanged &&
+    !publishedManifestChanged &&
+    !publishedScriptChanged &&
+    !versionChanged
+  ) {
+    console.log(`No package release required for ${currentPackage.name}.`);
+    continue;
+  }
+  if (!versionChanged) {
+    errors.push(
+      `Package contents changed without a version bump for ${currentPackage.name} ` +
+        `(still ${currentPackage.version}). Bump ${manifestPath} and update the package changelog specified in AGENTS.md before merging.`,
+    );
+    continue;
+  }
+  if (!isSemanticVersion(basePackage.version)) {
+    errors.push(
+      `Package version for ${currentPackage.name} at ${base}:${baseManifestPath} is not a valid semantic version: ${String(basePackage.version)}.`,
+    );
+    continue;
+  }
+  if (
+    compareSemanticVersions(currentPackage.version, basePackage.version) <= 0
+  ) {
+    errors.push(
+      `Package version must increase for ${currentPackage.name}: ${basePackage.version} -> ${currentPackage.version}.`,
+    );
+    continue;
+  }
+
   console.log(
-    `Package release requested: ${basePackage.version} -> ${currentPackage.version}.`,
+    `Package release requested for ${currentPackage.name}: ${basePackage.version} -> ${currentPackage.version}.`,
   );
+}
+
+if (errors.length > 0) {
+  throw new Error(errors.join('\n'));
 }

--- a/scripts/check-package-version.spec.mjs
+++ b/scripts/check-package-version.spec.mjs
@@ -24,7 +24,7 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function createRepository() {
+function createRepository(version = '1.0.0') {
   const root = mkdtempSync(join(tmpdir(), 'phase-version-check-'));
   fixtures.push(root);
 
@@ -35,7 +35,7 @@ function createRepository() {
 
   writeJson(join(root, 'package.json'), {
     name: 'phase',
-    version: '1.0.0',
+    version,
     type: 'module',
     scripts: { build: 'tsdown', prepare: 'lefthook install || true' },
     files: ['dist', 'LICENSE', 'README.md'],
@@ -77,10 +77,41 @@ function movePackage(root) {
   runGit(root, 'add', '.');
 }
 
-function createMovedRepository() {
-  const { root } = createRepository();
+function createMovedRepository(version) {
+  const { root } = createRepository(version);
   movePackage(root);
+  writeJson(join(root, 'scripts/publishable-packages.json'), [
+    'packages/phase',
+  ]);
+  runGit(root, 'add', '.');
   runGit(root, 'commit', '--quiet', '-m', 'move package');
+  return { root, base: runGit(root, 'rev-parse', 'HEAD') };
+}
+
+function createTwoPackageRepository() {
+  const { root } = createMovedRepository();
+  const packageRoot = join(root, 'packages/react');
+  writeJson(join(packageRoot, 'package.json'), {
+    name: '@usephase/react',
+    version: '1.0.0',
+    type: 'module',
+    scripts: { build: 'tsdown' },
+    files: ['dist'],
+    exports: { '.': './dist/index.js' },
+  });
+  mkdirSync(join(packageRoot, 'src'));
+  writeFileSync(
+    join(packageRoot, 'src/index.ts'),
+    'export const usePhase = 1;\n',
+  );
+  writeFileSync(join(packageRoot, 'tsconfig.json'), '{}\n');
+  writeFileSync(join(packageRoot, 'tsdown.config.ts'), 'export default {};\n');
+  writeJson(join(root, 'scripts/publishable-packages.json'), [
+    'packages/phase',
+    'packages/react',
+  ]);
+  runGit(root, 'add', '.');
+  runGit(root, 'commit', '--quiet', '-m', 'add react package');
   return { root, base: runGit(root, 'rev-parse', 'HEAD') };
 }
 
@@ -98,33 +129,6 @@ afterEach(() => {
 });
 
 describe('package release intent', () => {
-  it('accepts an unchanged package moved into the workspace', () => {
-    const { root, base } = createRepository();
-    movePackage(root);
-
-    const run = runCheck(root, base);
-
-    expect(run.status).toBe(0);
-    expect(run.stdout).toContain('No package release required.');
-    expect(run.stderr).toBe('');
-  });
-
-  it('rejects production source moved outside the package during migration', () => {
-    const { root, base } = createRepository();
-    movePackage(root);
-    const destination = join(root, 'apps/example/index.ts');
-    mkdirSync(dirname(destination), { recursive: true });
-    renameSync(join(root, 'packages/phase/src/index.ts'), destination);
-    runGit(root, 'add', '.');
-
-    const run = runCheck(root, base);
-
-    expect(run.status).toBe(1);
-    expect(run.stderr).toContain(
-      'Package contents changed without a version bump',
-    );
-  });
-
   it('accepts repository-only changes after the workspace move', () => {
     const { root, base } = createMovedRepository();
     writeFileSync(join(root, 'CONTRIBUTING.md'), '# Contributing\n');
@@ -132,7 +136,7 @@ describe('package release intent', () => {
     const run = runCheck(root, base);
 
     expect(run.status).toBe(0);
-    expect(run.stdout).toContain('No package release required.');
+    expect(run.stdout).toContain('No package release required for phase.');
   });
 
   it('rejects package source changes without a version bump', () => {
@@ -207,6 +211,201 @@ describe('package release intent', () => {
     expect(run.status).toBe(1);
     expect(run.stderr).toContain(
       'Package contents changed without a version bump',
+    );
+  });
+
+  it('checks release intent for every declared package', () => {
+    const { root, base } = createTwoPackageRepository();
+    writeFileSync(
+      join(root, 'packages/react/src/index.ts'),
+      'export const usePhase = 2;\n',
+    );
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for @usephase/react',
+    );
+  });
+
+  it('accepts an independent version bump for a changed package', () => {
+    const { root, base } = createTwoPackageRepository();
+    writeFileSync(
+      join(root, 'packages/react/src/index.ts'),
+      'export const usePhase = 2;\n',
+    );
+    const manifestPath = join(root, 'packages/react/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.version = '1.0.1';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(
+      'Package release requested for @usephase/react: 1.0.0 -> 1.0.1.',
+    );
+    expect(run.stdout).toContain('No package release required for phase.');
+  });
+
+  it('does not require a release for package test changes', () => {
+    const { root, base } = createTwoPackageRepository();
+    writeFileSync(
+      join(root, 'packages/react/src/index.spec.ts'),
+      'export const testOnly = true;\n',
+    );
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(
+      'No package release required for @usephase/react.',
+    );
+  });
+
+  it('rejects published bin changes without a version bump', () => {
+    const { root, base } = createTwoPackageRepository();
+    const manifestPath = join(root, 'packages/react/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.bin = { phase: './dist/index.js' };
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for @usephase/react',
+    );
+  });
+
+  it('rejects a package version that moves backward', () => {
+    const { root, base } = createMovedRepository();
+    const manifestPath = join(root, 'packages/phase/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.version = '0.9.0';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package version must increase for phase: 1.0.0 -> 0.9.0.',
+    );
+  });
+
+  it('accepts an increasing prerelease package version', () => {
+    const { root, base } = createMovedRepository('1.0.0-beta.2');
+    const manifestPath = join(root, 'packages/phase/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.version = '1.0.0-beta.10';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(
+      'Package release requested for phase: 1.0.0-beta.2 -> 1.0.0-beta.10.',
+    );
+  });
+
+  it('rejects source changes made while moving a declared package', () => {
+    const { root, base } = createMovedRepository();
+    renameSync(join(root, 'packages/phase'), join(root, 'packages/core'));
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/core',
+    ]);
+    writeFileSync(
+      join(root, 'packages/core/src/index.ts'),
+      'export const phase = 2;\n',
+    );
+    runGit(root, 'add', '-A');
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for phase',
+    );
+  });
+
+  it('accepts moving an unchanged declared package', () => {
+    const { root, base } = createMovedRepository();
+    renameSync(join(root, 'packages/phase'), join(root, 'packages/core'));
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/core',
+    ]);
+    runGit(root, 'add', '-A');
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain('No package release required for phase.');
+  });
+
+  it('matches a moved package by npm name when Git misses the rename', () => {
+    const { root, base } = createMovedRepository();
+    renameSync(join(root, 'packages/phase'), join(root, 'packages/core'));
+    writeJson(join(root, 'packages/core/package.json'), {
+      name: 'phase',
+      version: '1.0.0',
+    });
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/core',
+    ]);
+    runGit(root, 'add', '-A');
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for phase',
+    );
+  });
+
+  it('treats a changed npm name as a new package', () => {
+    const { root, base } = createMovedRepository();
+    const manifestPath = join(root, 'packages/phase/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.name = '@usephase/core';
+    manifest.version = '0.1.0';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(
+      'Package release requested for @usephase/core: new package at 0.1.0.',
+    );
+  });
+
+  it('rejects build script changes without a version bump', () => {
+    const { root, base } = createTwoPackageRepository();
+    const manifestPath = join(root, 'packages/react/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.scripts.build = 'tsdown --minify';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for @usephase/react',
+    );
+  });
+
+  it('rejects prebuild changes without a version bump', () => {
+    const { root, base } = createTwoPackageRepository();
+    const manifestPath = join(root, 'packages/react/package.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.scripts.prebuild = 'node prepare-build.mjs';
+    writeJson(manifestPath, manifest);
+
+    const run = runCheck(root, base);
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Package contents changed without a version bump for @usephase/react',
     );
   });
 });

--- a/scripts/detect-package-releases.mjs
+++ b/scripts/detect-package-releases.mjs
@@ -1,0 +1,63 @@
+import { spawnSync } from 'node:child_process';
+
+import { readPublishablePackages } from './publishable-packages.mjs';
+
+const NPM_REGISTRY_ARGUMENTS = [
+  '--registry=https://registry.npmjs.org',
+  '--@usephase:registry=https://registry.npmjs.org',
+];
+const pending = [];
+const requestedDirectory = process.argv[2];
+const declared = readPublishablePackages();
+const candidates = requestedDirectory
+  ? declared.filter(({ directory }) => directory === requestedDirectory)
+  : declared;
+
+if (candidates.length === 0) {
+  throw new Error(
+    `Package is not declared for publishing: ${requestedDirectory}`,
+  );
+}
+
+for (const { directory, manifest } of candidates) {
+  const result = spawnSync(
+    'npm',
+    ['view', manifest.name, 'versions', '--json', ...NPM_REGISTRY_ARGUMENTS],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    const stderr = result.stderr ?? '';
+    if (stderr.includes('E404')) {
+      pending.push(directory);
+      console.error(
+        `::notice::Unpublished package version detected: ${manifest.name}@${manifest.version}`,
+      );
+      continue;
+    }
+    const detail = stderr.trim() || result.error?.message || 'unknown error';
+    throw new Error(
+      `Failed to check published versions for ${manifest.name}: ${detail}`,
+    );
+  }
+
+  const published = JSON.parse(result.stdout);
+  const versions = Array.isArray(published) ? published : [published];
+  if (versions.includes(manifest.version)) {
+    console.error(
+      `::notice::${manifest.name}@${manifest.version} already exists`,
+    );
+    continue;
+  }
+
+  pending.push(directory);
+  console.error(
+    `::notice::Unpublished package version detected: ${manifest.name}@${manifest.version}`,
+  );
+}
+
+if (requestedDirectory) {
+  console.log(`package_name=${candidates[0].manifest.name}`);
+  console.log(`package_version=${candidates[0].manifest.version}`);
+}
+console.log(`packages=${JSON.stringify(pending)}`);
+console.log(`has_packages=${pending.length > 0}`);

--- a/scripts/detect-package-releases.spec.mjs
+++ b/scripts/detect-package-releases.spec.mjs
@@ -1,0 +1,302 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const SCRIPT = join(import.meta.dirname, 'detect-package-releases.mjs');
+const fixtures = [];
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createWorkspace() {
+  const root = mkdtempSync(join(tmpdir(), 'phase-release-detect-'));
+  fixtures.push(root);
+
+  writeJson(join(root, 'scripts/publishable-packages.json'), [
+    'packages/phase',
+  ]);
+  writeJson(join(root, 'packages/phase/package.json'), {
+    name: 'phase',
+    version: '1.0.0',
+  });
+
+  const bin = join(root, 'bin');
+  const npm = join(bin, 'npm');
+  mkdirSync(bin);
+  writeFileSync(
+    npm,
+    `#!/usr/bin/env node
+if (process.env.NPM_VIEW_ERROR) {
+  process.stderr.write(process.env.NPM_VIEW_ERROR);
+  process.exit(1);
+}
+process.stdout.write(process.env.NPM_VIEW_OUTPUT);
+`,
+  );
+  chmodSync(npm, 0o755);
+
+  return { root, bin };
+}
+
+function runDetect(
+  root,
+  bin,
+  npmOutput,
+  npmError = '',
+  packageDirectory,
+  path = `${bin}:${process.env.PATH}`,
+) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT, ...(packageDirectory ? [packageDirectory] : [])],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NPM_VIEW_ERROR: npmError,
+        NPM_VIEW_OUTPUT: npmOutput,
+        PATH: path,
+      },
+    },
+  );
+}
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+describe('package release detection', () => {
+  it('emits an empty matrix when every declared version is published', () => {
+    const { root, bin } = createWorkspace();
+
+    const run = runDetect(root, bin, '["0.9.0","1.0.0"]\n');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe('packages=[]\nhas_packages=false\n');
+    expect(run.stderr).toContain('phase@1.0.0 already exists');
+  });
+
+  it('emits a declared package whose version is not published', () => {
+    const { root, bin } = createWorkspace();
+
+    const run = runDetect(root, bin, '["0.9.0"]\n');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe('packages=["packages/phase"]\nhas_packages=true\n');
+    expect(run.stderr).toContain(
+      'Unpublished package version detected: phase@1.0.0',
+    );
+  });
+
+  it('treats a package missing from npm as unpublished', () => {
+    const { root, bin } = createWorkspace();
+
+    const run = runDetect(root, bin, '', 'npm error code E404\n');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe('packages=["packages/phase"]\nhas_packages=true\n');
+    expect(run.stderr).toContain(
+      'Unpublished package version detected: phase@1.0.0',
+    );
+  });
+
+  it('rejects a private package in the declared list', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/phase/package.json'), {
+      name: 'phase',
+      version: '1.0.0',
+      private: true,
+    });
+
+    const run = runDetect(root, bin, '["1.0.0"]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Declared package packages/phase must not be private',
+    );
+  });
+
+  it('ignores private packages that are not declared', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/private/package.json'), {
+      name: '@usephase/private',
+      version: '2.0.0',
+      private: true,
+    });
+
+    const run = runDetect(root, bin, '["1.0.0"]\n');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe('packages=[]\nhas_packages=false\n');
+    expect(run.stderr).not.toContain('@usephase/private');
+  });
+
+  it('preserves declared package order in the matrix', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/react/package.json'), {
+      name: '@usephase/react',
+      version: '1.0.0',
+    });
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/phase',
+      'packages/react',
+    ]);
+
+    const run = runDetect(root, bin, '["0.9.0"]\n');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe(
+      'packages=["packages/phase","packages/react"]\nhas_packages=true\n',
+    );
+  });
+
+  it('fails on a non-404 npm error', () => {
+    const { root, bin } = createWorkspace();
+
+    const run = runDetect(root, bin, '', 'npm error code E500\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain('npm error code E500');
+    expect(run.stdout).toBe('');
+  });
+
+  it('rejects a declared directory without a package manifest', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/missing',
+    ]);
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Declared package packages/missing does not exist',
+    );
+  });
+
+  it('rejects a declared directory with shell metacharacters', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/bad;touch/package.json'), {
+      name: 'bad-package',
+      version: '1.0.0',
+    });
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/bad;touch',
+    ]);
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Declared package directory must match packages/<name>',
+    );
+  });
+
+  it('rejects duplicate npm package names', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/other/package.json'), {
+      name: 'phase',
+      version: '2.0.0',
+    });
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/phase',
+      'packages/other',
+    ]);
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Declared npm package name is duplicated: phase',
+    );
+  });
+
+  it('reports a missing npm executable with package context', () => {
+    const { root, bin } = createWorkspace();
+
+    const run = runDetect(root, bin, '', '', undefined, '');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Failed to check published versions for phase',
+    );
+    expect(run.stderr).toContain('ENOENT');
+  });
+
+  it('can recheck one matrix package without considering later packages', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/react/package.json'), {
+      name: '@usephase/react',
+      version: '2.0.0',
+    });
+    writeJson(join(root, 'scripts/publishable-packages.json'), [
+      'packages/phase',
+      'packages/react',
+    ]);
+
+    const run = runDetect(root, bin, '["1.0.0"]\n', '', 'packages/phase');
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toBe(
+      'package_name=phase\npackage_version=1.0.0\npackages=[]\nhas_packages=false\n',
+    );
+    expect(run.stderr).not.toContain('@usephase/react');
+  });
+
+  it('rejects semantic versions beyond npm numeric limits', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/phase/package.json'), {
+      name: 'phase',
+      version: '9007199254740992.0.0',
+    });
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'must have a valid npm name and semantic version',
+    );
+  });
+
+  it('rejects an npm package name that could inject an output line', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/phase/package.json'), {
+      name: 'phase\nforged=true',
+      version: '1.0.0',
+    });
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'must have a valid npm name and semantic version',
+    );
+    expect(run.stdout).toBe('');
+  });
+
+  it('rejects a package configured to publish outside npmjs', () => {
+    const { root, bin } = createWorkspace();
+    writeJson(join(root, 'packages/phase/package.json'), {
+      name: 'phase',
+      version: '1.0.0',
+      publishConfig: { registry: 'https://registry.example.com' },
+    });
+
+    const run = runDetect(root, bin, '[]\n');
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain('must publish to https://registry.npmjs.org');
+  });
+});

--- a/scripts/publishable-packages.json
+++ b/scripts/publishable-packages.json
@@ -1,0 +1,1 @@
+["packages/phase"]

--- a/scripts/publishable-packages.mjs
+++ b/scripts/publishable-packages.mjs
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { isSemanticVersion } from './semantic-version.mjs';
+
+const NPM_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+
+/**
+ * Reads package manifests in the order listed in scripts/publishable-packages.json.
+ * Throws when the file is not a non-empty JSON array, an entry is not a valid
+ * package directory, a directory or npm name is repeated, or a manifest is
+ * missing, private, or has an invalid npm name or semantic version.
+ */
+export function readPublishablePackages(root = process.cwd()) {
+  const declared = JSON.parse(
+    readFileSync(resolve(root, 'scripts/publishable-packages.json'), 'utf8'),
+  );
+  if (!Array.isArray(declared) || declared.length === 0) {
+    throw new Error('Publishable packages must be a non-empty array');
+  }
+
+  const seen = new Set();
+  const packageNames = new Set();
+
+  return declared.map((directory) => {
+    if (
+      typeof directory !== 'string' ||
+      !/^packages\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(directory)
+    ) {
+      throw new Error(
+        `Declared package directory must match packages/<name>: ${String(directory)}`,
+      );
+    }
+    if (seen.has(directory)) {
+      throw new Error(
+        `Declared package directory is listed more than once: ${directory}`,
+      );
+    }
+    seen.add(directory);
+
+    let manifest;
+    try {
+      manifest = JSON.parse(
+        readFileSync(resolve(root, directory, 'package.json'), 'utf8'),
+      );
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        throw new Error(`Declared package ${directory} does not exist`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    if (manifest.private === true) {
+      throw new Error(`Declared package ${directory} must not be private`);
+    }
+    const publishRegistry = manifest.publishConfig?.registry;
+    if (
+      publishRegistry !== undefined &&
+      publishRegistry !== 'https://registry.npmjs.org' &&
+      publishRegistry !== 'https://registry.npmjs.org/'
+    ) {
+      throw new Error(
+        `Declared package ${directory} must publish to https://registry.npmjs.org`,
+      );
+    }
+    if (
+      typeof manifest.name !== 'string' ||
+      manifest.name.length > 214 ||
+      !NPM_PACKAGE_NAME.test(manifest.name) ||
+      !isSemanticVersion(manifest.version)
+    ) {
+      throw new Error(
+        `Declared package ${directory} must have a valid npm name and semantic version`,
+      );
+    }
+    if (packageNames.has(manifest.name)) {
+      throw new Error(
+        `Declared npm package name is duplicated: ${manifest.name}`,
+      );
+    }
+    packageNames.add(manifest.name);
+    return { directory, manifest };
+  });
+}

--- a/scripts/semantic-version.mjs
+++ b/scripts/semantic-version.mjs
@@ -1,0 +1,75 @@
+const SEMANTIC_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const MAX_LENGTH = 256;
+const MAX_NUMBER = 9007199254740991n;
+
+function parseSemanticVersion(value) {
+  if (typeof value !== 'string' || value.length > MAX_LENGTH) return;
+
+  const match = SEMANTIC_VERSION.exec(value);
+  if (!match) return;
+
+  const prerelease = match[4]?.split('.') ?? [];
+  if (
+    prerelease.some(
+      (identifier) =>
+        /^\d+$/.test(identifier) &&
+        identifier.length > 1 &&
+        identifier.startsWith('0'),
+    )
+  ) {
+    return;
+  }
+
+  const release = [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])];
+  if (release.some((identifier) => identifier > MAX_NUMBER)) return;
+
+  return { release, prerelease };
+}
+
+/** Returns whether a value follows npm's semantic-version syntax and limits. */
+export function isSemanticVersion(value) {
+  return parseSemanticVersion(value) !== undefined;
+}
+
+/**
+ * Compares valid semantic versions by precedence, ignoring build metadata.
+ * Returns -1, 0, or 1 and throws when either value is invalid.
+ */
+export function compareSemanticVersions(left, right) {
+  const a = parseSemanticVersion(left);
+  const b = parseSemanticVersion(right);
+  if (!a || !b) {
+    throw new Error(
+      `Cannot compare semantic versions because one or both values are invalid: left=${String(left)}, right=${String(right)}`,
+    );
+  }
+
+  for (let index = 0; index < a.release.length; index += 1) {
+    if (a.release[index] > b.release[index]) return 1;
+    if (a.release[index] < b.release[index]) return -1;
+  }
+
+  if (a.prerelease.length === 0) return b.prerelease.length === 0 ? 0 : 1;
+  if (b.prerelease.length === 0) return -1;
+
+  const identifiers = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < identifiers; index += 1) {
+    const leftIdentifier = a.prerelease[index];
+    const rightIdentifier = b.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return BigInt(leftIdentifier) > BigInt(rightIdentifier) ? 1 : -1;
+    }
+    if (leftNumeric) return -1;
+    if (rightNumeric) return 1;
+    return leftIdentifier > rightIdentifier ? 1 : -1;
+  }
+
+  return 0;
+}

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+const manifest = JSON.parse(readFileSync(0, 'utf8'));
+const expectedName = process.env.EXPECTED_PACKAGE_NAME;
+const expectedVersion = process.env.EXPECTED_PACKAGE_VERSION;
+
+if (manifest.name !== expectedName || manifest.version !== expectedVersion) {
+  throw new Error(
+    `Packed package name or version changed: expected ${expectedName}@${expectedVersion}, received ${manifest.name}@${manifest.version}`,
+  );
+}
+
+console.log(
+  `Packed package name and version verified: ${manifest.name}@${manifest.version}`,
+);

--- a/scripts/verify-packed-package.spec.mjs
+++ b/scripts/verify-packed-package.spec.mjs
@@ -1,0 +1,36 @@
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const SCRIPT = join(import.meta.dirname, 'verify-packed-package.mjs');
+
+function verify(manifest, name = 'phase', version = '1.0.0') {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: 'utf8',
+    input: JSON.stringify(manifest),
+    env: {
+      ...process.env,
+      EXPECTED_PACKAGE_NAME: name,
+      EXPECTED_PACKAGE_VERSION: version,
+    },
+  });
+}
+
+describe('packed package name and version', () => {
+  it('accepts the package name and version that were rechecked', () => {
+    const run = verify({ name: 'phase', version: '1.0.0' });
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain(
+      'Packed package name and version verified: phase@1.0.0',
+    );
+  });
+
+  it('rejects a package version changed by packing hooks', () => {
+    const run = verify({ name: 'phase', version: '9.0.0' });
+
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain(
+      'Packed package name or version changed: expected phase@1.0.0, received phase@9.0.0',
+    );
+  });
+});


### PR DESCRIPTION
The release workflow only knows about `phase`, so adding the core, React, and command packages would require copying detection and publish logic. The PR version check is also tied to one package, which can let package changes and release intent drift apart.

This change makes a committed, dependency-ordered package list the source of truth for both checks. The release workflow compares each declared version with npm, validates the merge commit, then runs unpublished packages through serialized publish legs. Each leg rechecks npm for safe reruns, builds and packs with pnpm, verifies the tarball name and version, installs a provenance-capable npm 11, and publishes to npmjs with OIDC and provenance.

## Reviewer notes

- The `release` GitHub environment is an operational approval gate. npm trusted-publisher Environment fields stay blank, and each publisher must explicitly allow direct `npm publish`.
- `phase@0.5.4` is already published, so merging this should exercise the clean no-op path. The next legitimate package release must verify the live OIDC exchange and provenance.
- When B5 enrolls `packages/cli`, its release-intent inputs must include `packages/skill/scanner/**` and `skills/phase/metadata.json`.
- Live registry detection emits an empty matrix for `phase@0.5.4`, and the packed tarball name/version check passes locally.

Closes DSN-2069